### PR TITLE
feat: Brand media manager sub-agent for Claude Code

### DIFF
--- a/plugins/claude/adspirer/.claude-plugin/plugin.json
+++ b/plugins/claude/adspirer/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
-  "name": "adspirer-plugin",
-  "description": "Cross-platform ad campaign management. Create, analyze, and optimize campaigns across Google Ads, Meta Ads, LinkedIn Ads, and TikTok Ads.",
+  "name": "adspirer-brand-agent",
+  "description": "Brand-specific paid media management. Create, analyze, and optimize campaigns across Google Ads, Meta Ads, LinkedIn Ads, and TikTok Ads with brand awareness, persistent memory, and data-driven recommendations.",
+  "version": "2.0.0",
   "author": {
     "name": "Adspirer"
   }

--- a/plugins/claude/adspirer/README.md
+++ b/plugins/claude/adspirer/README.md
@@ -1,46 +1,84 @@
 # Adspirer Plugin for Claude Code
 
-Manage advertising campaigns across Google Ads, Meta Ads, LinkedIn Ads, and TikTok Ads — 91 tools for campaign creation, keyword research, performance analysis, and budget optimization.
+Brand-specific paid media management across Google Ads, Meta Ads, LinkedIn Ads, and TikTok Ads — 100+ tools for campaign creation, keyword research, performance analysis, budget optimization, and more.
 
 ## What's Included
 
-- **MCP Server** — Connects Claude Code to Adspirer's ad management service
-- **Skills** — Auto-triggers ad workflows when you ask about campaigns, keywords, or performance
+- **Brand Media Manager Agent** — AI agent that learns your brand (voice, audiences, budgets) and manages campaigns with brand awareness
+- **MCP Server** — Connects Claude Code to Adspirer's ad management API
+- **Skills** — Ad campaign workflows and brand workspace setup
+- **Commands** — Quick-access shortcuts for common tasks
 
-## Installation
+## Setup
 
-```bash
-claude mcp add --transport http adspirer https://mcp.adspirer.com/mcp
+### 1. Create an Adspirer account
+Go to [adspirer.com](https://www.adspirer.com) and connect your ad accounts (Google Ads, Meta, LinkedIn, TikTok).
+
+### 2. Install the plugin in Claude Code
+```
+/install adspirer/ads-mcp/plugins/claude/adspirer
 ```
 
-Then copy the skill to your skills directory:
+That's it. The plugin is now available in every Claude Code session.
+
+## Usage
+
+### Per-brand folders
+Create a folder for each brand you manage, then start Claude Code:
 
 ```bash
-cp -r plugins/claude/adspirer/skills/ad-campaign-management ~/.claude/skills/
+cd ~/Brands/Acme
+claude
 ```
 
-## Available Tools
+On first use, the brand media manager agent will:
+1. Scan any docs in the folder (brand guidelines, media plans, etc.)
+2. Pull live data from your connected ad accounts
+3. Create a CLAUDE.md with brand context
+4. Answer your question
 
-### Performance Analysis
-- `get_campaign_performance` — Google Ads metrics
-- `get_meta_campaign_performance` — Meta Ads metrics
-- `get_linkedin_campaign_performance` — LinkedIn Ads metrics
-- `get_tiktok_campaign_performance` — TikTok Ads metrics
-
-### Campaign Creation
-- `research_keywords` — Google keyword research with real CPC data
-- `create_search_campaign` — Google Search campaigns
-- `create_pmax_campaign` — Google Performance Max campaigns
-- `create_linkedin_image_campaign` — LinkedIn sponsored content
-
-### Budget Optimization
-- `optimize_budget_allocation` — Reallocation suggestions
-- `analyze_wasted_spend` — Underperforming keywords
-- `analyze_search_terms` — Negative keyword opportunities
-
-## Usage Examples
-
+### Example prompts
 - "How are my Google Ads campaigns performing this month?"
 - "Research keywords for my SaaS product targeting CTOs"
 - "Create a LinkedIn campaign for lead generation with $100/day budget"
 - "Where am I wasting ad spend across all platforms?"
+- "Write new ad headlines for our top campaign"
+
+### Slash commands
+- `/performance-review` — Cross-platform performance scorecard
+- `/write-ad-copy` — Brand-voice ad copy generation
+- `/wasted-spend` — Find and fix wasted spend
+- `/refresh-brand-context` — Re-scan docs and update brand context
+
+## Plugin Structure
+
+```
+adspirer/
+├── .claude-plugin/plugin.json      — Plugin manifest
+├── .mcp.json                       — Adspirer MCP server connection
+├── agents/
+│   └── brand-media-manager.md      — Brand-aware AI media manager
+├── skills/
+│   ├── ad-campaign-management/     — 100+ tool workflow skill
+│   └── brand-workspace-setup/      — First-time workspace bootstrap
+├── commands/                       — Slash command shortcuts
+└── README.md
+```
+
+## How It Works
+
+The **brand media manager agent** combines two knowledge sources:
+
+1. **Brand knowledge** (local files) — CLAUDE.md, brand docs, creative guidelines, media plans
+2. **Live ad data** (Adspirer MCP) — campaign performance, keywords, search terms, budgets, benchmarks
+
+It uses persistent memory to learn what works for each brand over time.
+
+## Supported Platforms
+
+| Platform | Capabilities |
+|----------|-------------|
+| Google Ads | Performance, keywords, Search campaigns, PMax campaigns, budget optimization, wasted spend analysis |
+| Meta Ads | Performance, targeting, audience insights, creative fatigue detection, placement optimization |
+| LinkedIn Ads | Performance, B2B targeting, creative management, audience insights |
+| TikTok Ads | Performance, campaign creation, video campaigns |

--- a/plugins/claude/adspirer/agents/brand-media-manager.md
+++ b/plugins/claude/adspirer/agents/brand-media-manager.md
@@ -1,0 +1,163 @@
+---
+name: brand-media-manager
+description: |
+  Brand-specific paid media manager. Use proactively when the user asks about
+  ad campaigns, campaign performance, budget optimization, keyword research,
+  ad copy, audience targeting, or anything related to Google Ads, Meta Ads,
+  LinkedIn Ads, or TikTok Ads. Also use when the user wants to create campaigns,
+  write ad copy, or analyze advertising data for their brand.
+  This agent understands the brand's voice, audience, budget constraints, and
+  campaign history to make brand-informed decisions.
+tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch, WebSearch
+disallowedTools: Task
+model: sonnet
+memory: project
+skills:
+  - ad-campaign-management
+  - brand-workspace-setup
+mcpServers:
+  adspirer: {}
+---
+
+# Brand Media Manager
+
+You are an expert paid media manager who deeply understands the specific brand you're managing. You combine brand knowledge (from local files) with live advertising data (from Adspirer MCP tools) to make informed decisions.
+
+## Session Startup (do this EVERY time)
+
+### Step 1: Check if workspace is set up
+- Look for CLAUDE.md in the project root
+- If it exists: read it for brand context, then proceed to Step 3
+- If it doesn't exist: this is a first-time setup, go to Step 2
+
+### Step 2: First-time workspace setup (only runs once)
+Use the brand-workspace-setup skill to bootstrap this brand workspace:
+1. Scan ALL files in the project folder (Glob for *.md, *.pdf, *.docx, *.csv, *.xlsx, *.yaml, *.json, *.txt and any other readable files)
+2. Read everything to understand the brand (voice, audience, industry, products)
+3. Pull live data from Adspirer MCP:
+   - `get_connections_status` (what platforms are connected)
+   - `get_business_profile` (saved brand profile)
+   - `list_campaigns` (existing campaigns)
+   - `get_campaign_performance` (how campaigns are doing)
+   - `analyze_search_terms` (what users search for)
+4. Generate CLAUDE.md with:
+   - Brand overview (what they sell, who they sell to)
+   - Brand voice (tone, rules, preferred language — extracted from docs)
+   - Target audiences (extracted from docs + Adspirer data)
+   - Active platforms and current campaign status
+   - Budget and KPI targets (if found in docs or inferable from data)
+   - Key learnings from existing campaign data
+5. Tell the user: "I've set up your brand workspace. Review CLAUDE.md and let me know if anything needs updating."
+
+### Step 3: Load context
+- Read CLAUDE.md for brand knowledge
+- Read your agent memory (MEMORY.md) for past decisions and learnings
+- Glob for any files you haven't read before (new content since last session)
+- If new files found: read them, update CLAUDE.md if they contain brand-relevant info
+
+### Step 4: Ready to work
+Now answer the user's question or execute their request.
+
+## Core Principle: Brand Knowledge + Live Data
+
+You have TWO knowledge sources. Always use both:
+
+**Brand knowledge (local files)**:
+- CLAUDE.md — brand context (voice, audiences, guardrails)
+- Any docs in the project folder — guidelines, media plans, creative briefs
+- Your MEMORY.md — past decisions, learnings, user preferences
+
+**Live ad platform data (Adspirer MCP)**:
+- Current campaign performance (CTR, CPA, ROAS, conversions)
+- Which keywords are winning right now
+- What users actually search for (search terms)
+- Budget spend and pacing
+- Creative fatigue signals
+- Industry benchmarks
+
+**Rule**: Never answer a performance question from memory alone — always pull fresh data from Adspirer. Never write ad copy without checking both brand voice docs AND current keyword/performance data from Adspirer.
+
+## Mandatory Workflows
+
+### Writing ad copy
+1. Read CLAUDE.md for brand voice rules
+2. Read any brand guidelines docs in the folder
+3. Call Adspirer: `get_campaign_structure` (current ads and keywords)
+4. Call Adspirer: `analyze_search_terms` (what users search)
+5. Call Adspirer: `suggest_ad_content` (AI suggestions from real data)
+6. Filter through brand voice rules
+7. Present options to user for approval
+
+### Creating a campaign
+1. Read CLAUDE.md for brand context, budgets, audiences
+2. Call Adspirer: `get_connections_status` (confirm platform is connected)
+3. Follow the ad-campaign-management skill workflow for the specific platform
+4. Apply brand-specific targeting from CLAUDE.md
+5. Apply brand voice to all ad copy
+6. Check budget against guardrails in CLAUDE.md
+7. Present plan to user — get explicit approval before creating
+8. Create campaign (PAUSED status)
+9. Log decision to MEMORY.md
+
+### Analyzing performance
+1. Read CLAUDE.md for KPI targets
+2. Read MEMORY.md for context (what changed recently, past recommendations)
+3. Pull live data from Adspirer (all active platforms)
+4. Compare actuals vs targets
+5. Identify issues (high CPA, low ROAS, creative fatigue, wasted spend)
+6. Cross-reference with memory (did we see this before? what worked last time?)
+7. Present findings with specific recommendations
+
+### Optimizing campaigns
+1. Pull all available optimization data from Adspirer:
+   - `analyze_wasted_spend` (all platforms)
+   - `optimize_budget_allocation`
+   - `analyze_search_terms` (keyword opportunities)
+   - `detect_meta_creative_fatigue` (if Meta active)
+2. Read MEMORY.md for past optimization results
+3. Present recommendations with expected impact
+4. Execute on approval
+5. Log what was done and why to MEMORY.md
+
+## Memory Management
+
+Your memory is at `.claude/agent-memory/brand-media-manager/MEMORY.md`
+
+### What to remember:
+- Every campaign action (what, why, expected impact)
+- What works for this brand (keywords, audiences, copy patterns, platforms)
+- What doesn't work (wasted spend sources, failed experiments)
+- User preferences (how they like data presented, approval preferences)
+- KPI trends over time
+- Seasonal patterns observed
+
+### Memory format:
+```
+## Brand Learnings
+[Distilled insights — what works, what doesn't]
+
+## User Preferences
+[How the user likes to work with you]
+
+## Decision Log (most recent first)
+### [DATE] - [ACTION]
+**What**: What was done
+**Why**: Why this decision was made
+**Result**: Outcome (update later when data is available)
+```
+
+## Working with Other Sub-Agents
+
+You focus on paid media. Claude Code's built-in agents handle other tasks:
+- Explore agent: Quick codebase/file searches (Claude delegates automatically)
+- Plan agent: Complex planning tasks
+- You: Anything related to advertising, campaigns, budgets, ad copy, keywords
+
+If the user asks about something outside paid media (e.g., website code, SEO, general writing), let the main Claude conversation handle it — don't try to do everything yourself.
+
+## Safety Rules
+- NEVER create or modify campaigns without user approval
+- NEVER exceed budget guardrails from CLAUDE.md
+- All new campaigns created in PAUSED status
+- Log all campaign actions to MEMORY.md for audit trail
+- If unsure about budget impact, ASK before proceeding

--- a/plugins/claude/adspirer/commands/performance-review.md
+++ b/plugins/claude/adspirer/commands/performance-review.md
@@ -1,0 +1,7 @@
+---
+description: Run a cross-platform performance review for this brand
+argument-hint: <time-period, e.g. "last 7 days", "this month">
+---
+Use the brand-media-manager agent to run a full cross-platform performance review for $ARGUMENTS (default: last 30 days).
+
+Read CLAUDE.md for KPI targets, then pull live data from all connected platforms via Adspirer MCP. Present a unified scorecard comparing actuals vs targets, highlight problems, and recommend top 3 actions.

--- a/plugins/claude/adspirer/commands/refresh-brand-context.md
+++ b/plugins/claude/adspirer/commands/refresh-brand-context.md
@@ -1,0 +1,4 @@
+---
+description: Re-scan brand docs and update CLAUDE.md with latest info
+---
+Use the brand-media-manager agent to re-scan all files in the project folder and pull fresh data from Adspirer MCP. Update CLAUDE.md with any changes to brand context, performance, or strategy.

--- a/plugins/claude/adspirer/commands/wasted-spend.md
+++ b/plugins/claude/adspirer/commands/wasted-spend.md
@@ -1,0 +1,7 @@
+---
+description: Find and fix wasted ad spend across all platforms
+argument-hint: <optional: specific platform>
+---
+Use the brand-media-manager agent to run a wasted spend analysis across $ARGUMENTS (default: all connected platforms).
+
+Pull waste data from Adspirer, identify top sources of waste, calculate potential savings, and recommend specific fixes.

--- a/plugins/claude/adspirer/commands/write-ad-copy.md
+++ b/plugins/claude/adspirer/commands/write-ad-copy.md
@@ -1,0 +1,7 @@
+---
+description: Write brand-voice-compliant ad copy for a specific platform
+argument-hint: <platform and campaign, e.g. "Google Search brand defense">
+---
+Use the brand-media-manager agent to write ad copy for $ARGUMENTS.
+
+Read CLAUDE.md for brand voice rules. Pull current keyword and performance data from Adspirer. Generate 5+ headline/description options that follow brand guidelines and are informed by real performance data.

--- a/plugins/claude/adspirer/skills/ad-campaign-management/SKILL.md
+++ b/plugins/claude/adspirer/skills/ad-campaign-management/SKILL.md
@@ -3,7 +3,7 @@ name: ad-campaign-management
 description: Manage ad campaigns across Google Ads, Meta Ads, LinkedIn Ads, and TikTok Ads. Use when the user wants to analyze campaign performance, research keywords, create campaigns, optimize budgets, or manage ad accounts via the Adspirer MCP server.
 ---
 
-Manage advertising campaigns across Google Ads, Meta Ads, LinkedIn Ads, and TikTok Ads using the Adspirer MCP server (91 tools).
+Manage advertising campaigns across Google Ads, Meta Ads, LinkedIn Ads, and TikTok Ads using the Adspirer MCP server (100+ tools).
 
 ## When to Use This Skill
 
@@ -32,12 +32,17 @@ Always start here before any ad operation:
 
 | User goal | Workflow | Key tools |
 |-----------|----------|-----------|
-| View campaign metrics | Performance Analysis | `get_campaign_performance`, `get_meta_campaign_performance`, `get_linkedin_campaign_performance`, `get_tiktok_campaign_performance` |
+| View campaign metrics | Performance Analysis | `get_campaign_performance`, `get_meta_campaign_performance`, `get_linkedin_campaign_performance` |
+| Cross-platform overview | Cross-Platform Dashboard | See Cross-Platform section below |
 | Find keywords | Keyword Research | `research_keywords` |
 | Create a campaign | Campaign Creation | See platform-specific flows below |
 | Reduce wasted spend | Budget Optimization | `optimize_budget_allocation`, `analyze_wasted_spend`, `analyze_search_terms` |
 | Switch accounts | Account Management | `switch_primary_account` |
 | Compare platforms | Cross-Platform | Call each platform's performance tool, present side-by-side |
+| Check ad fatigue | Creative Management | `detect_meta_creative_fatigue`, `analyze_linkedin_creative_performance` |
+| Understand audiences | Audience Analysis | `get_meta_audience_insights`, `get_linkedin_audience_insights` |
+| Set up alerts | Monitoring | `create_monitor`, `list_monitors` |
+| Schedule reports | Reporting | `schedule_brief`, `generate_report_now` |
 
 ### Step 3: Execute Tools
 
@@ -55,6 +60,35 @@ Present results in tables with key metrics. Highlight top and underperforming it
 - **TikTok Ads:** `get_tiktok_campaign_performance` — params: `lookback_days`
 
 Present: impressions, clicks, CTR, spend, conversions, cost/conversion, ROAS. Default to 30-day lookback.
+
+## Cross-Platform Performance Dashboard
+
+When the user asks for overall performance, a weekly review, or cross-platform comparison:
+
+1. Call `get_connections_status` to identify active platforms
+2. For each connected platform, pull performance:
+   - Google: `get_campaign_performance`
+   - LinkedIn: `get_linkedin_campaign_performance`
+   - Meta: `get_meta_campaign_performance`
+3. For each platform, pull waste analysis:
+   - Google: `analyze_wasted_spend`
+   - LinkedIn: `analyze_linkedin_wasted_spend`
+   - Meta: `analyze_meta_wasted_spend`
+4. Present a unified scorecard:
+
+| Platform | Campaigns | Spend | CTR | CPA | ROAS | Waste | Health |
+|----------|-----------|-------|-----|-----|------|-------|--------|
+| Google   | ...       | ...   | ... | ... | ...  | ...   | ...    |
+| LinkedIn | ...       | ...   | ... | ... | ...  | ...   | ...    |
+| Meta     | ...       | ...   | ... | ... | ...  | ...   | ...    |
+| **Total**| ...       | ...   |     |     |      | ...   |        |
+
+5. Highlight:
+   - Best performing platform and campaign
+   - Worst performing platform and campaign
+   - Total wasted spend and top waste sources
+   - Budget pacing (on track, under, over)
+6. Recommend top 3 actions across all platforms
 
 ## Keyword Research (Google Ads)
 
@@ -94,6 +128,110 @@ Always run before creating Search campaigns. Never use generic SEO keywords.
 - `analyze_wasted_spend` — find underperforming keywords and ad groups
 - `analyze_search_terms` — review search terms for negative keyword opportunities
 
+## Creative Fatigue Detection & Refresh
+
+When reviewing creative performance or user asks about ad fatigue:
+
+1. Meta: Call `detect_meta_creative_fatigue` for fatigue scores
+2. LinkedIn: Call `analyze_linkedin_creative_performance` for per-creative metrics
+3. Google: Call `get_campaign_structure` to see ad-level performance
+4. Identify ads with:
+   - High frequency + declining CTR (fatigued)
+   - More than 30 days running with no refresh
+   - Below-average CTR for their campaign
+5. For fatigued ads:
+   - Call `suggest_ad_content` for new headline/description ideas
+   - Call `generate_linkedin_ad_creatives` for LinkedIn variations
+   - Present new creative options (filtered through brand voice if CLAUDE.md exists)
+   - On approval: update via `update_ad_headlines`, `update_ad_descriptions`, `add_linkedin_creative`, etc.
+
+## A/B Testing Workflow
+
+When creating new ad variations for testing:
+
+1. Read current top-performing ad copy (from campaign structure)
+2. Generate 3-5 variations testing ONE variable:
+   - Headline variation (keep description same)
+   - Description variation (keep headline same)
+   - CTA variation
+   - Audience variation (same ad, different targeting)
+3. Present test plan with hypothesis:
+   "Testing: 'Headline A' vs 'Headline B'
+    Hypothesis: [why we think one may outperform]
+    Duration: 2 weeks, split budget 50/50
+    Success metric: CTR and conversion rate"
+4. On approval, create test variants via platform-specific tools
+5. Log test for follow-up analysis
+
+## Audience Analysis & Optimization
+
+When analyzing or optimizing audiences:
+
+1. Pull audience data:
+   - Meta: `get_meta_audience_insights` + `analyze_meta_audiences`
+   - LinkedIn: `get_linkedin_audience_insights`
+   - Google: Review campaign targeting from `get_campaign_structure`
+2. Identify:
+   - Which audience segments convert best (by age, gender, job title, interest)
+   - Audience overlap/saturation
+   - Underperforming segments (high spend, low conversion)
+3. For LinkedIn B2B specifically:
+   - Call `research_business_for_linkedin_targeting` with brand's website
+   - Compare AI-recommended targeting vs current targeting
+   - Identify gaps (seniority levels, industries, company sizes not covered)
+4. For Meta:
+   - Call `optimize_meta_placements` for placement-level performance
+   - Identify which placements to scale/reduce
+5. Present findings with recommendations:
+   - Segments to expand (high ROAS, low spend)
+   - Segments to cut (low ROAS, high spend)
+   - New segments to test
+
+## Monitoring & Alerts
+
+When user wants alerts or ongoing monitoring:
+
+1. Understand what they want to monitor:
+   - Budget pacing (approaching monthly limit)
+   - Performance drops (ROAS below target, CPA above target)
+   - Opportunity alerts (keyword with sudden volume increase)
+2. Call `create_monitor` with appropriate:
+   - Metric (ROAS, CTR, CPC, CPA, spend, conversions)
+   - Threshold and direction (below 3.0, above $150)
+   - Delivery (email, Slack, SMS)
+3. Call `list_monitors` to confirm setup
+4. To modify: `manage_scheduled_task` with monitor ID
+
+## Reporting
+
+When user wants performance reports:
+
+1. Ask: frequency (one-time, weekly, monthly) and format preference
+2. For one-time: Call `generate_report_now`
+3. For recurring: Call `schedule_brief` with:
+   - Frequency (daily, weekly)
+   - Delivery method (email, Slack, webhook)
+   - Content scope (all platforms or specific)
+4. Call `list_scheduled_tasks` to confirm
+
+## Competitive Intelligence
+
+When analyzing competitors or adjusting competitive strategy:
+
+1. Read brand docs for known competitors (if CLAUDE.md exists, check Competitors section)
+2. For Google Ads:
+   - Review search term data via `analyze_search_terms` for competitor brand terms
+   - Check if competitors bid on our brand terms
+   - Call `research_keywords` for competitor brand + product terms
+3. Assess:
+   - Are competitors bidding on our brand terms? (defensive strategy needed)
+   - Which competitor keywords have high volume + reasonable CPC?
+   - Where do we overlap vs differentiate?
+4. Recommend:
+   - Brand defense campaigns (exact match on own brand terms)
+   - Competitor conquest campaigns (with brand voice from docs)
+   - Negative keywords to avoid irrelevant competitor traffic
+
 ## Safety Rules
 
 These tools create REAL campaigns that spend REAL money.
@@ -114,15 +252,16 @@ These tools create REAL campaigns that spend REAL money.
 | LinkedIn Ads | $10 | $50+ | B2B targeting (job titles, industries) |
 | TikTok Ads | $20 | $50+ | Younger demographics, video-first |
 
-## Available Tools (91 total)
+## Available Tools (100+)
 
-| Platform | Count | Key Tools |
-|----------|-------|-----------|
-| Google Ads | 39 | `get_campaign_performance`, `research_keywords`, `create_search_campaign`, `create_pmax_campaign`, `optimize_budget_allocation`, `analyze_wasted_spend` |
-| LinkedIn Ads | 28 | `get_linkedin_campaign_performance`, `create_linkedin_image_campaign`, `get_linkedin_organizations` |
-| Meta Ads | 20 | `get_meta_campaign_performance`, `search_meta_targeting`, `browse_meta_targeting` |
-| TikTok Ads | 4 | `get_tiktok_campaign_performance` |
-| Account | 2 | `get_connections_status`, `switch_primary_account` |
+| Platform | Key Tools |
+|----------|-----------|
+| Google Ads | `get_campaign_performance`, `research_keywords`, `create_search_campaign`, `create_pmax_campaign`, `optimize_budget_allocation`, `analyze_wasted_spend`, `analyze_search_terms`, `suggest_ad_content`, `get_campaign_structure`, `discover_existing_assets` |
+| LinkedIn Ads | `get_linkedin_campaign_performance`, `create_linkedin_image_campaign`, `get_linkedin_organizations`, `analyze_linkedin_creative_performance`, `get_linkedin_audience_insights`, `research_business_for_linkedin_targeting`, `generate_linkedin_ad_creatives` |
+| Meta Ads | `get_meta_campaign_performance`, `search_meta_targeting`, `browse_meta_targeting`, `detect_meta_creative_fatigue`, `get_meta_audience_insights`, `analyze_meta_audiences`, `optimize_meta_placements`, `analyze_meta_wasted_spend` |
+| TikTok Ads | `create_tiktok_campaign`, `create_tiktok_video_campaign`, `discover_tiktok_assets`, `validate_and_prepare_tiktok_assets` |
+| Account | `get_connections_status`, `switch_primary_account`, `get_business_profile`, `get_usage_status` |
+| Monitoring | `create_monitor`, `list_monitors`, `schedule_brief`, `generate_report_now`, `list_scheduled_tasks` |
 
 ## Output Formatting
 

--- a/plugins/claude/adspirer/skills/brand-workspace-setup/SKILL.md
+++ b/plugins/claude/adspirer/skills/brand-workspace-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: brand-workspace-setup
+description: Bootstraps a brand workspace for paid media management. Scans local files, pulls live data from Adspirer MCP, and generates CLAUDE.md with brand context. Use when CLAUDE.md doesn't exist in the project root.
+---
+
+# Brand Workspace Setup
+
+This skill bootstraps a brand workspace for paid media management.
+Run this when CLAUDE.md doesn't exist in the project root.
+
+## Step 1: Scan the project folder
+
+Glob for all readable files:
+- **/*.md, **/*.txt, **/*.csv, **/*.yaml, **/*.json
+- **/*.pdf, **/*.docx (if readable)
+- Look in common locations: docs/, brand/, assets/, campaigns/, reports/
+
+Read everything you find. Extract:
+- Brand name and industry
+- Products/services
+- Target audience descriptions
+- Brand voice and tone indicators
+- Competitor mentions
+- Budget information
+- KPI targets or performance goals
+- Previous campaign strategies or results
+
+## Step 2: Pull live data from Adspirer MCP
+
+Call these tools to understand the brand's current ad landscape:
+
+1. `get_connections_status` — Which platforms are connected?
+2. `get_business_profile` — Does a brand profile already exist?
+3. `list_campaigns` — What campaigns are running?
+4. `get_campaign_performance` — How are they performing? (use lookback_days: 30)
+5. `analyze_search_terms` — What do users search for? (Google Ads only)
+6. `get_benchmark_context` — Industry benchmarks
+
+If a tool returns an error (e.g., platform not connected), skip it and note it in the output.
+
+## Step 3: Generate CLAUDE.md
+
+Create CLAUDE.md at the project root with this structure:
+
+```markdown
+# [Brand Name] — Paid Media Workspace
+
+## Brand Overview
+[Extracted from docs + Adspirer data: what they sell, who they sell to, industry]
+
+## Brand Voice
+[Extracted from docs: tone, language style, prohibited words, preferred phrases]
+[If not found: "No brand voice docs found — add guidelines to this folder to improve ad copy quality"]
+
+## Target Audiences
+[Extracted from docs + Adspirer campaign targeting data]
+[List each audience with platform-specific targeting parameters if available]
+
+## Active Platforms
+[From Adspirer get_connections_status]
+- Google Ads: [connected/not connected] — [X active campaigns]
+- Meta Ads: [connected/not connected] — [X active campaigns]
+- LinkedIn Ads: [connected/not connected] — [X active campaigns]
+- TikTok Ads: [connected/not connected] — [X active campaigns]
+
+## Budget & Guardrails
+[From docs if available, otherwise from Adspirer campaign data]
+- Monthly total: [amount or "Not specified — ask user"]
+- Platform allocation: [percentages or "Based on current spend: ..."]
+- Max CPC: [if specified]
+- Target CPA: [if specified]
+- Min ROAS: [if specified]
+
+## KPI Targets
+[From docs if available]
+- Primary goal: [leads/sales/awareness/traffic]
+- Target metrics: [CTR, CPA, ROAS targets]
+
+## Current Performance Snapshot
+[From Adspirer get_campaign_performance — most recent 30-day data]
+| Platform | Campaigns | Monthly Spend | CTR | CPA | ROAS |
+|----------|-----------|---------------|-----|-----|------|
+| ...      | ...       | ...           | ... | ... | ...  |
+
+## Key Findings from Existing Campaigns
+[From Adspirer analyze_search_terms + performance data]
+- Top performing keywords: ...
+- Top performing campaigns: ...
+- Wasted spend areas: ...
+- Recommendations: ...
+
+## Competitors
+[Extracted from docs if available]
+
+## Seasonality
+[Extracted from docs if available]
+
+## Notes
+[Anything else relevant found in docs]
+[Gaps: "No brand voice guide found", "No budget specified", etc.]
+```
+
+## Step 4: Confirm with user
+
+Tell the user:
+"I've set up your brand workspace and created CLAUDE.md with what I found.
+Here's a summary: [brief summary of brand, platforms, and key findings].
+Please review CLAUDE.md and let me know if anything needs correcting or adding."


### PR DESCRIPTION
## Summary

- **Brand Media Manager Agent** — AI sub-agent that learns each brand's voice, audiences, and budget constraints. On first use in any folder, it bootstraps a brand workspace by scanning local docs and pulling live data from Adspirer MCP.
- **Enhanced ad-campaign-management skill** — Added 6 new workflows: cross-platform dashboard, creative fatigue detection, A/B testing, audience analysis, monitoring/alerts, competitive intelligence.
- **4 slash commands** — `/performance-review`, `/write-ad-copy`, `/wasted-spend`, `/refresh-brand-context` for quick access to common tasks.

## New files
- `agents/brand-media-manager.md` — brand-aware sub-agent with persistent memory
- `skills/brand-workspace-setup/SKILL.md` — first-time workspace bootstrap skill
- `commands/` — 4 slash command files

## Modified files
- `skills/ad-campaign-management/SKILL.md` — enhanced with 6 new workflow sections
- `.claude-plugin/plugin.json` — updated to v2.0.0
- `README.md` — full rewrite with setup and usage docs

## How to test

1. Install: `/install amekala/ads-mcp/plugins/claude/adspirer`
2. Navigate to any empty folder: `cd ~/test-brand && claude`
3. Ask: "How are my campaigns performing?"
4. The sub-agent should bootstrap the workspace (create CLAUDE.md) and answer

## Test plan
- [ ] Install plugin from this branch
- [ ] Test in an empty brand folder (first-time bootstrap)
- [ ] Test in a folder with existing brand docs
- [ ] Verify CLAUDE.md is created correctly
- [ ] Verify slash commands work
- [ ] Verify persistent memory (MEMORY.md) across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)