### PR TITLE
Improve agent onboarding flow

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,12 @@
+---
+description: Set up your brand workspace — connect to Adspirer and pull campaign data
+---
+Use the performance-marketing-agent agent to run the full workspace setup:
+
+1. Connect to Adspirer ad accounts (triggers OAuth if needed)
+2. Scan this folder for brand docs (guidelines, media plans, audience profiles)
+3. Pull live campaign data from all connected platforms (Google Ads, Meta, LinkedIn, TikTok)
+4. Create CLAUDE.md with brand context, performance snapshot, and KPI targets
+5. Present a summary of what was found and what you can help with
+
+Run the complete Workspace Setup Flow from your instructions.


### PR DESCRIPTION
## Summary
- Replaced forced auto-start (model ignored it) with guided welcome + setup flow
- Added `/setup` slash command for easy first-time workspace initialization
- Used full MCP tool names (`mcp__adspirer__*`) for reliable tool resolution

## What Changed
- **Agent prompt**: Instead of "MUST call tools on first message" (which the model ignored), the agent now guides users to say "set it up" or run `/setup`
- **New `/setup` command**: Users can type `/setup` to trigger the full workspace initialization
- **Full MCP tool names**: Changed `get_connections_status` → `mcp__adspirer__get_connections_status` etc.

## Test Plan
1. Install plugin fresh in an empty brand folder
2. Type "hi" — should get welcome message with setup instructions
3. Type "set it up" or `/setup` — should run full workspace initialization (13 turns: connect Adspirer, scan files, pull data, create CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)