### PR TITLE
Harden campaign creation reliability across skills and agents

### DIFF
--- a/agents/performance-marketing-agent.md
+++ b/agents/performance-marketing-agent.md
@@ -214,6 +214,25 @@ You have TWO knowledge sources. Always use both:
     - Call `mcp__adspirer__add_structured_snippets` — pick relevant headers, extract values from website
     - Call `mcp__adspirer__list_campaign_extensions` — verify everything was added
 12. Log decision to MEMORY.md
+13. Tell the user conversion action primary/secondary setup is manual in Google Ads UI (not configurable through MCP tools).
+
+### Campaign execution contract (mandatory)
+1. Bind every write operation to explicit IDs (campaign_id/ad_group_id). Never rely on "latest campaign" context.
+2. After creation, run per-campaign readback verification:
+   - campaign status
+   - ad group count
+   - ads count
+   - keyword count and match-type profile
+   - extension counts
+3. If verification fails:
+   - run one targeted remediation pass for missing assets only
+   - re-verify once
+4. Report outcome strictly as:
+   - `SUCCESS` when all verification checks pass
+   - `PARTIAL_SUCCESS` when campaign exists but required assets are missing/unverifiable
+   - `FAILED` when creation fails
+5. Always report requested-vs-actual bidding strategy and keyword match types.
+6. Never claim success when extension state is unverifiable.
 
 ### Analyzing performance
 1. Read CLAUDE.md for KPI targets

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,3 +197,24 @@ Checks performed:
 7. OpenClaw files present (claw.json + SKILL.md with valid metadata)
 8. Shared templates exist
 9. MCP endpoint reachable (with `--live`)
+
+## Reliability Contract For Campaign Creation
+
+To prevent false-positive "campaign created" outcomes, skills and agents follow a strict completion contract:
+
+1. **Verification before success**: creation is only `SUCCESS` after per-campaign readback confirms required assets.
+2. **Status semantics**:
+   - `SUCCESS`: all required checks pass
+   - `PARTIAL_SUCCESS`: campaign exists but required assets are missing/unverifiable
+   - `FAILED`: campaign creation failed
+3. **One targeted remediation pass**: if verification fails, fix only missing asset classes once, then re-verify.
+4. **Extension fallback**: if `list_campaign_extensions` fails, retry once and cross-check with campaign structure before concluding.
+5. **Ad quality guardrails**: include unique keyword themes in headlines and validate all text lengths before submission.
+6. **Known limitation**: conversion action primary/secondary configuration is manual in Google Ads UI and not currently configurable via Adspirer MCP tools.
+
+This contract is implemented across:
+- shared templates (`shared/skills/*`)
+- generated client skills (Cursor/Codex/Claude Code)
+- agent instructions (`agents/`, `plugins/*/agents/`)
+- Cursor/Codex rules
+- OpenClaw standalone skill

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.1.2] - 2026-02-26
+
+### Changed — Campaign Creation Reliability Hardening
+- Added launch **Definition of Done** checks in shared skills to prevent false-success reporting when campaigns are missing ads, keywords, or extensions.
+- Added strict completion statuses: `SUCCESS`, `PARTIAL_SUCCESS`, `FAILED`.
+- Added extension verification fallback logic when `list_campaign_extensions` fails (retry once + cross-check before final status).
+- Added per-campaign verification/readback requirements in agent instructions across Cursor, Codex, and Claude Code variants.
+- Added ad quality guardrails requiring keyword-theme coverage in headlines and length validation before submission.
+- Added explicit platform limitation guidance: conversion action primary/secondary setup is manual in Google Ads UI (not configurable through Adspirer MCP tools).
+- Aligned OpenClaw standalone skill with the same reliability and reporting contract.
+
+### Propagation
+- Updated source templates in `shared/skills/`.
+- Regenerated Cursor/Codex/Claude skill outputs via `scripts/sync-skills.sh`.
+- Verified sync and integrity with `scripts/validate.sh` (all checks passing).
+
 ## [1.1.1] - 2026-02-22
 
 ### Added — Shared Skills Architecture

--- a/plugins/codex/adspirer/agents/performance-marketing-agent.toml
+++ b/plugins/codex/adspirer/agents/performance-marketing-agent.toml
@@ -171,6 +171,25 @@ You have TWO knowledge sources. Always use both:
     - Call `add_structured_snippets` — pick relevant headers
     - Call `list_campaign_extensions` — verify everything was added
 12. Note what was done for future reference
+13. Tell the user conversion action primary/secondary setup is manual in Google Ads UI (not configurable through MCP tools).
+
+### Campaign execution contract (mandatory)
+1. Bind every write operation to explicit IDs (campaign_id/ad_group_id). Never rely on "latest campaign" context.
+2. After campaign creation, run a per-campaign verification readback:
+   - campaign status
+   - ad group count
+   - ads count
+   - keyword count and match-type profile
+   - extension counts
+3. If verification fails:
+   - run one targeted remediation pass for missing assets only
+   - re-verify once
+4. Report outcome as:
+   - `SUCCESS` when all verification checks pass
+   - `PARTIAL_SUCCESS` when campaign exists but required assets are missing/unverifiable
+   - `FAILED` when campaign creation fails
+5. Always include requested-vs-actual bidding strategy and match types in final output.
+6. Never claim success when extension state is unverifiable.
 
 ### Analyzing performance
 1. Read AGENTS.md for KPI targets

--- a/plugins/codex/adspirer/rules/campaign-safety.rules
+++ b/plugins/codex/adspirer/rules/campaign-safety.rules
@@ -1,5 +1,10 @@
 # Campaign Safety Rules
 # Prevent direct API calls to ad platforms — all operations must go through Adspirer MCP
+# Operational guardrails for campaign reliability:
+# - Never report success until ads, keywords, and extensions are verified.
+# - Use statuses: SUCCESS / PARTIAL_SUCCESS / FAILED.
+# - If extension verification fails, retry once and then report PARTIAL_SUCCESS with explicit gaps.
+# - Conversion action primary/secondary setup is manual in Google Ads UI (not configurable via MCP tools).
 
 prefix_rule(
     pattern = ["curl", "https://ads.google.com"],

--- a/plugins/codex/adspirer/skills/adspirer-ads/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-ads/SKILL.md
@@ -192,6 +192,12 @@ Always run before creating Search campaigns. Never use generic SEO keywords.
    - `add_callout_extensions` — add 4+ callouts (use value props from research)
    - `add_structured_snippets` — add relevant structured snippets
 8. `list_campaign_extensions` — verify all extensions were added
+9. Run post-create verification on this campaign using `get_campaign_structure`:
+   - confirm ad groups exist
+   - confirm keywords exist with expected match-type profile
+   - confirm at least one RSA exists
+10. If any required asset is missing, run one targeted remediation pass for the missing asset class only, then re-verify.
+11. Do not report success until this campaign passes Launch Definition of Done.
 
 **Google Ads Performance Max:**
 1. Campaign Research — crawl brand + competitor websites, present research brief
@@ -294,6 +300,70 @@ After adding all extensions, always call `list_campaign_extensions` to verify:
 - Callouts are present
 - Structured snippets are showing
 - Report back to the user what was added
+
+If `list_campaign_extensions` fails:
+1. Retry once with a corrected payload or narrower scope.
+2. Cross-check extension state with `get_campaign_structure`.
+3. If extension state is still unverifiable, report `PARTIAL_SUCCESS` and explicitly list what could not be confirmed.
+
+## Launch Definition of Done (Required before reporting success)
+
+For each created campaign, all checks below must pass:
+
+1. Campaign exists and status is `PAUSED` (unless user explicitly approved activation).
+2. Expected ad group count exists.
+3. Expected keywords exist, with the planned match-type profile (EXACT/PHRASE/BROAD as specified).
+4. At least one RSA exists with expected headline/description counts.
+5. Required extensions exist (sitelinks, callouts, structured snippets for Google Ads campaigns).
+6. Requested-vs-actual bidding strategy matches, or any drift is explicitly called out.
+
+### Status protocol (mandatory)
+
+- `SUCCESS`: all Launch Definition of Done checks pass for all targeted campaigns.
+- `PARTIAL_SUCCESS`: campaign shell exists, but one or more required assets are missing/unverifiable after one targeted remediation pass.
+- `FAILED`: campaign creation itself failed.
+
+Never report `SUCCESS` when any verification check failed or could not be confirmed.
+
+### Per-campaign action ledger (mandatory)
+
+For every campaign you create or edit, log and return:
+- campaign name + campaign_id
+- ad_group_id values touched
+- keyword add/update counts
+- RSA counts (headlines/descriptions)
+- extension counts (sitelinks/callouts/snippets)
+- verification result per campaign (`PASS`/`FAIL`)
+
+## Ad Quality Guardrails (Google Ads)
+
+### Keyword-to-headline coverage
+
+For each ad group, include unique high-intent target keywords in RSA headlines. At minimum:
+- cover top 3-5 keyword themes from the ad group's keyword list
+- avoid generic headline sets that omit core search intent terms
+- when competitive terms are targeted, keep competitor names in keywords only if required by strategy and avoid naming competitors in ad copy unless user explicitly approves
+
+### Asset length validation checklist (before submission)
+
+- RSA headline: <= 30 characters
+- RSA description: <= 90 characters
+- Path fields: <= 15 characters each
+- Sitelink text: <= 25 characters
+- Sitelink description lines: <= 35 characters each
+- Callout text: <= 25 characters
+- Structured snippet values: follow platform limits and keep concise
+
+Validate lengths before `create_*` or `add_*` calls. If limits are exceeded, rewrite and re-validate before submitting.
+
+## Conversion Tracking Limitation
+
+Adspirer MCP currently does not configure Google Ads conversion action settings (primary vs secondary) directly.
+
+When campaign goals depend on conversion action priority:
+1. create campaigns in PAUSED status
+2. tell the user exact Google Ads UI path to configure conversion actions manually
+3. report campaign creation as complete only after clarifying this manual step
 
 ## Budget Optimization (Google Ads)
 

--- a/plugins/codex/adspirer/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-performance-review/SKILL.md
@@ -10,3 +10,4 @@ Run a full cross-platform performance review for $ARGUMENTS (default: last 30 da
 3. Compare actuals vs KPI targets from AGENTS.md
 4. Present a unified scorecard table with all platforms
 5. Highlight top problems and recommend top 3 actions
+6. If requested, include Campaign Integrity Audit fields (status, ad groups, ads, keywords, extensions, bidding drift).

--- a/plugins/codex/adspirer/skills/adspirer-setup/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-setup/SKILL.md
@@ -107,6 +107,9 @@ Generate `AGENTS.md` at the project root. Combine local files + Adspirer data:
 ## Notes
 [Anything else relevant found in docs]
 [Gaps: "No brand voice guide found", "No budget specified", etc.]
+[Known constraints:
+- Conversion action primary/secondary setup is configured manually in Google Ads UI (not via Adspirer MCP)
+- Campaign creation should be considered complete only after post-create verification of ads, keywords, and extensions]
 ```
 
 Fill in every section with real data. Leave placeholders only for sections where no data was found — and note the gap.

--- a/plugins/codex/adspirer/skills/adspirer-wasted-spend/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-wasted-spend/SKILL.md
@@ -10,3 +10,4 @@ Run a wasted spend analysis across $ARGUMENTS (default: all connected platforms)
 3. Call `analyze_linkedin_wasted_spend` for LinkedIn Ads waste
 4. Call `analyze_search_terms` to find irrelevant search terms
 5. Identify top sources of waste, calculate potential savings, and recommend specific fixes with expected impact
+6. If campaigns have zero ads or zero keywords, report a build-integrity blocker before optimization advice.

--- a/plugins/codex/adspirer/skills/adspirer-write-ad-copy/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-write-ad-copy/SKILL.md
@@ -11,3 +11,4 @@ Write ad copy for $ARGUMENTS.
 4. Call `suggest_ad_content` for AI-generated suggestions based on real data
 5. Generate 5+ headline/description options that follow brand guidelines and are informed by real performance data
 6. Present options for user approval
+7. Include a validation table with character counts and keyword-theme coverage for the proposed headlines/descriptions.

--- a/plugins/cursor/adspirer/.cursor/agents/performance-marketing-agent.md
+++ b/plugins/cursor/adspirer/.cursor/agents/performance-marketing-agent.md
@@ -77,6 +77,25 @@ You have TWO knowledge sources. Always use both:
 7. Present plan to user — get explicit approval before creating
 8. Create campaign (PAUSED status)
 9. Log decision to MEMORY.md
+10. Tell the user conversion action primary/secondary setup is done manually in Google Ads UI (not via MCP).
+
+### Campaign execution contract (mandatory)
+1. Bind every write operation to explicit IDs (campaign_id/ad_group_id). Never rely on "latest campaign" context.
+2. After creation, run a per-campaign readback before reporting outcome:
+   - campaign status
+   - ad group count
+   - ads count
+   - keyword count and match-type profile
+   - extension counts
+3. If verification fails:
+   - run one targeted remediation pass for missing assets only
+   - re-verify once
+4. Report status strictly as:
+   - `SUCCESS`: all verification checks pass
+   - `PARTIAL_SUCCESS`: campaign exists but required assets are missing or unverifiable
+   - `FAILED`: campaign creation failed
+5. Always include requested-vs-actual bidding and match types in the final report.
+6. Do not claim success when extension state is unverifiable.
 
 ### Analyzing performance
 1. Read BRAND.md for KPI targets

--- a/plugins/cursor/adspirer/.cursor/rules/brand-workspace.mdc
+++ b/plugins/cursor/adspirer/.cursor/rules/brand-workspace.mdc
@@ -18,3 +18,5 @@ When working on advertising, campaign, or marketing tasks in this project:
 5. **Always use live data** from the Adspirer MCP server alongside brand context. Never answer performance questions from memory alone — pull fresh data.
 
 6. **Update BRAND.md** when significant changes happen (new platforms connected, new brand docs added, major strategy shifts). Update MEMORY.md after every campaign action with what was done and why.
+
+7. **Known platform constraints must be surfaced proactively.** For Google Ads workflows, remind users that conversion action primary/secondary configuration is manual in Google Ads UI (not currently configurable via Adspirer MCP tools).

--- a/plugins/cursor/adspirer/.cursor/rules/use-adspirer.mdc
+++ b/plugins/cursor/adspirer/.cursor/rules/use-adspirer.mdc
@@ -26,4 +26,17 @@ When working with advertising or ad campaign tasks using the Adspirer MCP tools,
 
 8. **Ad extensions are mandatory for Google Ads campaigns.** After creating any Google Search or PMax campaign, always add sitelinks, callout extensions, and structured snippets.
 
+9. **Verification before success is mandatory.** Do not report success until each targeted campaign is read back and confirmed to have:
+   - expected ad groups
+   - ads present
+   - keywords present
+   - extensions present or explicitly marked as unverifiable
+
+10. **Use strict completion statuses.**
+   - `SUCCESS`: all required assets verified
+   - `PARTIAL_SUCCESS`: campaign exists but assets are missing/unverifiable after one targeted remediation pass
+   - `FAILED`: campaign creation failed
+
+11. **Never claim success on unverifiable extension state.** If extension verification tools fail, retry once and then report `PARTIAL_SUCCESS` with explicit gaps.
+
 See the `adspirer-ads` skill for the full tool reference and detailed workflows.

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-performance-review/SKILL.md
@@ -12,3 +12,10 @@ Run a full cross-platform performance review:
 5. Present a unified scorecard comparing actuals vs targets
 6. Highlight top performers, underperformers, and wasted spend
 7. Recommend top 3 actions across all platforms
+8. If the user asks for launch QA or campaign integrity, run a Campaign Integrity Audit:
+   - campaign status
+   - ad group count
+   - ads count
+   - keyword count and match-type mix
+   - extension counts
+   - bidding strategy requested vs actual

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-setup/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-setup/SKILL.md
@@ -112,6 +112,9 @@ Generate `BRAND.md` at the project root. Combine local files + Adspirer data:
 ## Notes
 [Anything else relevant found in docs]
 [Gaps: "No brand voice guide found", "No budget specified", etc.]
+[Known constraints:
+- Conversion action primary/secondary setup is configured manually in Google Ads UI (not via Adspirer MCP)
+- Campaign creation should be considered complete only after post-create verification of ads, keywords, and extensions]
 ```
 
 Fill in every section with real data. Leave placeholders only for sections where no data was found — and note the gap.

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-wasted-spend/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-wasted-spend/SKILL.md
@@ -14,3 +14,6 @@ Run a wasted spend analysis across all connected platforms:
 4. Present total wasted spend, top waste sources per platform, and potential monthly savings
 5. Recommend specific fixes (negative keywords, audience exclusions, budget shifts)
 6. Get user approval before making changes
+7. Before optimization recommendations, verify campaign build integrity for target campaigns:
+   - if ads count = 0 or keyword count = 0, flag as Build Integrity Issue
+   - do not proceed with optimization recommendations until missing assets are fixed or explicitly excluded

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-write-ad-copy/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-write-ad-copy/SKILL.md
@@ -12,3 +12,9 @@ Write ad copy informed by brand voice and real performance data:
 5. Filter all suggestions through brand voice rules from BRAND.md
 6. Present 5+ headline/description options with reasoning
 7. Get user approval before applying changes
+8. Include a validation table in the response with:
+   - headline/description text
+   - character count
+   - pass/fail vs platform limits
+   - target keyword theme mapped to each headline
+9. Ensure top ad group keyword themes are represented in the headline set before finalizing.

--- a/plugins/openclaw/SKILL.md
+++ b/plugins/openclaw/SKILL.md
@@ -112,6 +112,9 @@ Campaigns are created directly in ad platforms through API calls. All campaigns 
 3. `suggest_ad_content` — generate ad headlines and descriptions
 4. `validate_and_prepare_assets` — validate everything before creation
 5. `create_search_campaign` — create the campaign (PAUSED)
+6. `add_sitelinks` + `add_callout_extensions` + `add_structured_snippets` — add ad extensions
+7. `list_campaign_extensions` — verify extension state
+8. `get_campaign_structure` — verify ads and keywords exist before reporting success
 
 **Google Ads Performance Max (PMax):**
 PMax campaigns use Google's AI to run ads across Search, Display, YouTube, Gmail, and Discover simultaneously. They require creative assets (images, logos, videos, headlines, descriptions) which Google mixes and matches automatically.
@@ -196,6 +199,42 @@ Set up automated monitoring and reporting.
 - `switch_primary_account` — change which ad account is active for a platform
 - `get_usage_status` — check tool call quota and subscription tier
 - `get_business_profile` / `infer_business_profile` / `save_business_profile` — manage business context
+
+## Launch Definition of Done (Required before reporting success)
+
+For each campaign created or materially changed, all checks below must pass:
+
+1. Campaign exists and has the intended status (`PAUSED` by default).
+2. Expected ad group count exists.
+3. Expected keywords exist with planned match-type profile.
+4. At least one ad is present with expected asset counts.
+5. Required extensions are present for Google Ads campaigns (sitelinks, callouts, structured snippets).
+6. Requested-vs-actual bidding strategy is verified and any drift is explicitly reported.
+
+### Status protocol
+
+- `SUCCESS`: all required checks pass.
+- `PARTIAL_SUCCESS`: campaign exists but required assets are missing/unverifiable after one targeted remediation pass.
+- `FAILED`: campaign creation or update failed.
+
+Never report `SUCCESS` when any required verification check fails or is unverifiable.
+
+### Verification fallback for extension endpoints
+
+If `list_campaign_extensions` fails:
+1. Retry once.
+2. Cross-check with `get_campaign_structure`.
+3. If still unverifiable, return `PARTIAL_SUCCESS` and list explicit gaps.
+
+### Ad quality guardrails
+
+- Include unique high-intent keyword themes in headlines for each ad group.
+- Validate text lengths before submit (headline, description, paths, sitelinks, callouts, snippets).
+- Rewrite and re-validate if any field exceeds limits.
+
+### Conversion tracking limitation
+
+Primary/secondary conversion action configuration is manual in Google Ads UI and is not currently configurable through Adspirer MCP tools. Always call this out when launch goals depend on conversion prioritization.
 
 ---
 

--- a/shared/skills/adspirer-performance-review/SKILL.md
+++ b/shared/skills/adspirer-performance-review/SKILL.md
@@ -18,6 +18,13 @@ Run a full cross-platform performance review:
 5. Present a unified scorecard comparing actuals vs targets
 6. Highlight top performers, underperformers, and wasted spend
 7. Recommend top 3 actions across all platforms
+8. If the user asks for launch QA or campaign integrity, run a Campaign Integrity Audit:
+   - campaign status
+   - ad group count
+   - ads count
+   - keyword count and match-type mix
+   - extension counts
+   - bidding strategy requested vs actual
 <!-- END:CURSOR_CLAUDE -->
 <!-- BEGIN:CODEX -->
 Run a full cross-platform performance review for $ARGUMENTS (default: last 30 days).
@@ -27,4 +34,5 @@ Run a full cross-platform performance review for $ARGUMENTS (default: last 30 da
 3. Compare actuals vs KPI targets from {{CONTEXT_FILE}}
 4. Present a unified scorecard table with all platforms
 5. Highlight top problems and recommend top 3 actions
+6. If requested, include Campaign Integrity Audit fields (status, ad groups, ads, keywords, extensions, bidding drift).
 <!-- END:CODEX -->

--- a/shared/skills/adspirer-setup/SKILL.md
+++ b/shared/skills/adspirer-setup/SKILL.md
@@ -119,6 +119,9 @@ Generate `{{CONTEXT_FILE}}` at the project root. Combine local files + Adspirer 
 ## Notes
 [Anything else relevant found in docs]
 [Gaps: "No brand voice guide found", "No budget specified", etc.]
+[Known constraints:
+- Conversion action primary/secondary setup is configured manually in Google Ads UI (not via Adspirer MCP)
+- Campaign creation should be considered complete only after post-create verification of ads, keywords, and extensions]
 ```
 
 Fill in every section with real data. Leave placeholders only for sections where no data was found — and note the gap.

--- a/shared/skills/adspirer-wasted-spend/SKILL.md
+++ b/shared/skills/adspirer-wasted-spend/SKILL.md
@@ -20,6 +20,9 @@ Run a wasted spend analysis across all connected platforms:
 4. Present total wasted spend, top waste sources per platform, and potential monthly savings
 5. Recommend specific fixes (negative keywords, audience exclusions, budget shifts)
 6. Get user approval before making changes
+7. Before optimization recommendations, verify campaign build integrity for target campaigns:
+   - if ads count = 0 or keyword count = 0, flag as Build Integrity Issue
+   - do not proceed with optimization recommendations until missing assets are fixed or explicitly excluded
 <!-- END:CURSOR_CLAUDE -->
 <!-- BEGIN:CODEX -->
 Run a wasted spend analysis across $ARGUMENTS (default: all connected platforms).
@@ -29,4 +32,5 @@ Run a wasted spend analysis across $ARGUMENTS (default: all connected platforms)
 3. Call `analyze_linkedin_wasted_spend` for LinkedIn Ads waste
 4. Call `analyze_search_terms` to find irrelevant search terms
 5. Identify top sources of waste, calculate potential savings, and recommend specific fixes with expected impact
+6. If campaigns have zero ads or zero keywords, report a build-integrity blocker before optimization advice.
 <!-- END:CODEX -->

--- a/shared/skills/adspirer-write-ad-copy/SKILL.md
+++ b/shared/skills/adspirer-write-ad-copy/SKILL.md
@@ -18,6 +18,12 @@ Write ad copy informed by brand voice and real performance data:
 5. Filter all suggestions through brand voice rules from {{CONTEXT_FILE}}
 6. Present 5+ headline/description options with reasoning
 7. Get user approval before applying changes
+8. Include a validation table in the response with:
+   - headline/description text
+   - character count
+   - pass/fail vs platform limits
+   - target keyword theme mapped to each headline
+9. Ensure top ad group keyword themes are represented in the headline set before finalizing.
 <!-- END:CURSOR_CLAUDE -->
 <!-- BEGIN:CODEX -->
 Write ad copy for $ARGUMENTS.
@@ -28,4 +34,5 @@ Write ad copy for $ARGUMENTS.
 4. Call `suggest_ad_content` for AI-generated suggestions based on real data
 5. Generate 5+ headline/description options that follow brand guidelines and are informed by real performance data
 6. Present options for user approval
+7. Include a validation table with character counts and keyword-theme coverage for the proposed headlines/descriptions.
 <!-- END:CODEX -->


### PR DESCRIPTION
## Summary
- Add deterministic launch verification contract across shared skills: Definition of Done checks, strict `SUCCESS`/`PARTIAL_SUCCESS`/`FAILED` statuses, extension verification fallback, and one-pass targeted remediation guidance.
- Improve ad-quality safeguards: keyword-theme coverage in headlines, asset character-limit validation, and explicit requested-vs-actual bidding/match-type reporting.
- Propagate updates across generated Cursor/Codex/Claude skills, harden Cursor/Codex/Claude agent instructions and rules, and align OpenClaw standalone skill with the same reliability contract.
- Document known platform constraint: conversion action primary/secondary setup is manual in Google Ads UI (not configurable through Adspirer MCP tools).
- Update architecture/changelog to reflect propagation model and reliability semantics.

## Test plan
- [x] Run `./scripts/sync-skills.sh`
- [x] Run `./scripts/validate.sh`
- [x] Confirm validation passes (39/39)
- [x] Confirm generated skill files are synced for Cursor/Codex/Claude
- [x] Confirm no brand-specific guidance was introduced in shared skill templates

Made with [Cursor](https://cursor.com)