### PR TITLE
fix: commands, agents and the OpenClaw skill were outside the contract lint

### DIFF
--- a/commands/performance-review.md
+++ b/commands/performance-review.md
@@ -5,7 +5,7 @@ argument-hint: <time-period, e.g. "last 7 days", "this month">
 Run a full cross-platform performance review for $ARGUMENTS (default: last 30 days).
 
 1. Read CLAUDE.md for KPI targets and brand context
-2. Pull live data from all connected platforms via Adspirer MCP tools: `get_campaign_performance`, `get_linkedin_campaign_performance`, `get_meta_campaign_performance`
+2. Pull live data from all connected platforms. Follow `adspirer-mcp` for the call contract: `get_campaign_performance` (Google) and `get_meta_campaign_performance` (Meta) are direct calls; LinkedIn, TikTok, Amazon, and ChatGPT Ads go through their router with `{"action": "execute", "tool_name": "..."}`
 3. Compare actuals vs KPI targets from CLAUDE.md
 4. Present a unified scorecard table with all platforms
 5. Highlight top problems and recommend top 3 actions

--- a/commands/refresh-brand-context.md
+++ b/commands/refresh-brand-context.md
@@ -5,6 +5,6 @@ Re-scan all files in the project folder and pull fresh data from Adspirer MCP. U
 
 1. Scan folder for any new or updated brand docs (guidelines, media plans, audience profiles)
 2. Call `get_connections_status` to check current platform connections
-3. Call `get_campaign_performance`, `get_linkedin_campaign_performance`, `get_meta_campaign_performance` for latest metrics
+3. Pull latest metrics: `get_campaign_performance` and `get_meta_campaign_performance` are direct calls; other platforms go through their router (`{"action": "execute", "tool_name": "..."}`). See `adspirer-mcp`.
 4. Call `get_business_profile` for any profile updates
 5. Update CLAUDE.md with the refreshed data — merge new info, update performance numbers, note any changes

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -11,14 +11,15 @@ Run the full brand workspace setup. Follow these steps in order:
    - As a fallback: run `claude mcp add --transport http adspirer https://mcp.adspirer.com/mcp` via Bash, then tell the user to restart Claude Code, run `/mcp` to authenticate, then run `/adspirer:setup` again.
    - If the MCP server is registered but not authenticated: tell the user "Run `/mcp`, find the Adspirer server, and authenticate it. Then run `/adspirer:setup` again."
 2. **Scan local folder** for brand docs — use Glob to find files: `**/*.md`, `**/*.txt`, `**/*.csv`, `**/*.yaml`, `**/*.json`, `**/*.pdf`. Read any files found.
-3. **Pull live campaign data** from all connected platforms — call these Adspirer MCP tools directly (in parallel where possible):
-   - `get_connections_status`
-   - `get_business_profile`
-   - `list_campaigns`
+3. **Pull live campaign data** from the platforms that came back connected. Follow `adspirer-mcp` for the call contract.
+
+   Direct calls:
+   - `get_connections_status` — run this first; skip any platform it reports as not connected
    - `get_campaign_performance` (lookback_days: 30)
-   - `list_linkedin_campaigns`
-   - `get_linkedin_campaign_performance` (lookback_days: 30)
    - `get_meta_campaign_performance` (lookback_days: 30)
-   - `get_benchmark_context`
+
+   Through a router, with `{"action": "execute", "tool_name": "...", "arguments": {...}}`:
+   - `google_ads` → `list_campaigns`, `get_business_profile`, `get_benchmark_context`
+   - `linkedin_ads` → `list_linkedin_campaigns`, `get_linkedin_campaign_performance` (lookback_days: 30)
 4. **Create CLAUDE.md** at the project root with: brand context from scanned docs, connected platforms and account info, performance snapshot with key metrics, KPI targets
 5. **Present a summary** of everything found — accounts connected, campaigns discovered, key metrics, and what you can help with

--- a/plugins/openclaw/SKILL.md
+++ b/plugins/openclaw/SKILL.md
@@ -68,7 +68,28 @@ This is not a reference guide. This skill drives automation. You read and write 
 
 ## How It Works
 
-This skill is powered by the **Adspirer MCP server** (175+ tools across 4 ad platforms). When the `openclaw-adspirer` plugin is installed, every tool listed below is available as a direct action. The same tool surface is exposed as REST at `https://api.adspirer.ai` (auth via Personal Access Tokens — `sk_live_...`).
+This skill is powered by the **Adspirer MCP server**, covering Google Ads, Meta Ads, TikTok Ads, LinkedIn Ads, Amazon Ads, and ChatGPT Ads. The same tool surface is exposed as REST at `https://api.adspirer.ai` (auth via Personal Access Tokens — `sk_live_...`).
+
+### Calling the tools
+
+Only a few tools are callable by name: `start_here`, `search_tools`, `get_tool_schema`,
+`get_connections_status`, `get_usage_status`, `switch_primary_account`, `get_campaign_performance`
+(Google), `get_meta_campaign_performance`, `audit_conversion_tracking`, `echo_test`.
+
+**Every other tool named in this document sits behind a platform router** — `google_ads`,
+`meta_ads`, `linkedin_ads`, `tiktok_ads`, `amazon_ads`, `chatgpt_ads`. Call the router twice:
+
+```
+{"action": "list_tools"}                                    # free, always first
+{"action": "execute", "tool_name": "...", "arguments": {}}  # exact name from step 1
+```
+
+Calling a routed tool by name returns "tool not found". `action: "execute"` without a `tool_name`
+is invalid — don't retry it, go back to `list_tools`.
+
+Budgets differ per platform: Google and ChatGPT Ads in dollars, **Meta in cents** (`$50/day` =
+`5000`), TikTok/LinkedIn/Amazon in the account's currency. Campaigns are created **paused** on every
+platform.
 
 ### Setup (One-Time)
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -112,6 +112,24 @@ done
 [ -z "$bad" ] && pass || fail "routed tool named without the two-step or a protocol reference:$bad"
 
 # ---------------------------------------------------------------------------
+# Skills were not the only place the stale contract hid. commands/ and agents/ and the
+# hand-maintained OpenClaw skill all name routed tools too, and none of them are SKILL.md.
+echo ""; echo "--- Tool-call contract: commands, agents, hand-maintained skills ---"
+EXTRA_CONTRACT_FILES="commands/*.md agents/*.md plugins/openclaw/SKILL.md skills/performance-marketing-agent/SKILL.md"
+
+check "Non-skill files naming a routed tool teach list_tools or defer to adspirer-mcp"
+bad=""
+for f in $EXTRA_CONTRACT_FILES; do
+  [ -f "$f" ] || continue
+  for sentinel in $ROUTED_SENTINELS; do
+    if grep -q "$sentinel" "$f" 2>/dev/null; then
+      grep -qE 'list_tools|adspirer-mcp|"action": "execute"' "$f" || bad="$bad $f"
+      break
+    fi
+  done
+done
+[ -z "$bad" ] && pass || fail "routed tool named without the contract:$bad"
+
 echo ""; echo "--- URL allowlist ---"
 check "No forbidden URLs"
 # Only an actual linkable URL is a violation. Naming a forbidden path inside a


### PR DESCRIPTION
## The hole

`validate.sh` inspected only `SKILL.md` files inside the generated skill trees. Four files name
routed tools and none of them qualified:

| File | Named directly |
|---|---|
| `commands/performance-review.md` | `get_linkedin_campaign_performance` |
| `commands/refresh-brand-context.md` | `get_linkedin_campaign_performance` |
| `commands/setup.md` | `list_campaigns`, `get_linkedin_campaign_performance` |
| `plugins/openclaw/SKILL.md` | `get_linkedin_campaign_performance`, `get_tiktok_campaign_performance` |

Under federation those live behind platform routers, so an agent following them calls a tool that
isn't in `tools/list`. **106/106 passed while this sat in the same repo** — exactly the bug we
removed from the skills, still live in the slash commands users run every day.

## Fix

Each now routes through `{"action": "execute", "tool_name": ...}` or defers to `adspirer-mcp`.

The lint is extended to `commands/*.md`, `agents/*.md`, `plugins/openclaw/SKILL.md`, and
`skills/performance-marketing-agent/SKILL.md`. Verified it fails on the pre-fix files and passes on
the fixed ones — the check earns its keep rather than decorating a green build.

OpenClaw's skill also advertised "175+ tools across 4 ad platforms". There are six platforms, and
the count drifts, so it's gone.

`./scripts/validate.sh` → **107/107**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LiDsW9XF3Y6k17a6mCFSv