### PR TITLE
feat(skills): weave in artifacts, Sites, and host schedulers

### DIFF
--- a/plugins/chatgpt/adspirer/skills/adspirer-agent/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-agent/SKILL.md
@@ -66,6 +66,42 @@ promo that ended. Ask rather than assume.
 The workflow skills stay platform-agnostic. When one of them needs a platform's field rules, load
 that platform's skill.
 
+## Showing work, and repeating work
+
+Do the work first. Packaging comes after the answer, never instead of it.
+
+
+**When the user wants something durable and shareable, offer a Site.** A client-facing dashboard an
+agency updates weekly, a reporting portal across brands. A Site is hosted at a production URL, so
+treat publishing as an outward-facing act: ask first, and **default to invitation-only**. Ad spend,
+performance, customer lists, and lead-form submissions are confidential — never make them public
+without the user explicitly saying so, and spell out what would become visible before you do.
+
+For a one-off visual, a table or chart in the conversation is usually the right size of answer.
+
+**When the user wants something to happen on a schedule, use this host's scheduler.** Offer to set it
+up — they can create one just by asking. Everything they've automated then lives in one place they
+can see, pause, and edit, and the result arrives where they already are.
+
+Good candidates: a Monday performance review, a mid-month pacing check, an alert when CPA passes a
+ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
+
+ChatGPT tasks run whether or not the user is online and notify by push and email. A **monitoring
+task** is the right shape for "tell me if my CPA moves" — it re-checks and stays quiet until there's
+something worth saying. Active tasks are capped per plan (roughly 3 on Go, 5 on Plus, 15 on Pro), so
+if creation fails, that's usually why.
+
+
+Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
+live conversation. Say what the cadence will cost before setting it up — weekly is the right default
+for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.
+
+If this host has no scheduler, or the user wants the report by **email** rather than in a chat,
+Adspirer's `monitoring_and_reporting` router does server-side monitors, scheduled briefs, and
+research jobs. Discovery on it is free: `{"action": "list_tools"}`.
+
+Details, limits, and privacy rules: `references/host-surfaces.md`.
+
 ## Talking about money
 
 Use the account's currency and never silently convert it. Quote budgets as the user said them

--- a/plugins/chatgpt/adspirer/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-agent/references/host-surfaces.md
@@ -1,0 +1,140 @@
+# Host surfaces: artifacts, sites, and scheduled tasks
+
+Your host may offer ways to show work and repeat work that the terminal or the chat transcript
+can't. Use them when they genuinely fit. Don't announce a capability the host doesn't have.
+
+## Anything recurring: use the host's scheduler when it has one
+
+**If the host can schedule work, schedule it there.** The user gets one place to see, pause, and edit
+everything they've automated, and the result lands where they already are — in the conversation, with
+a notification. Offer to set it up rather than describing the UI; on both hosts the user can create a
+task just by asking.
+
+Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
+competitor's landing page, a nudge before a budget resets.
+
+**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
+worth anything:
+
+- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
+  Nothing to worry about.
+- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
+  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
+  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
+  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
+  one hour.
+
+Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
+today's spend; if it's past 6pm, just summarize what changed."
+
+Adspirer also has its own server-side monitors and email briefs, under the
+`monitoring_and_reporting` router — threshold alerts on ROAS, CPA, spend and CTR, scheduled reports,
+and async research jobs. Reach for those when the host has **no** scheduler at all (a plain CLI), when
+the user wants the report to arrive as **email** rather than in a chat, or when they want an alert to
+keep firing after they stop using this assistant. Otherwise prefer the host.
+
+Discovery on that router is free — `{"action": "list_tools"}` — as are `list_monitors`,
+`list_scheduled_tasks`, `get_monitor_history`, and `test_monitor`.
+
+---
+
+## Claude — artifacts
+
+An artifact is a live page published from the session to a private URL on claude.ai. It updates in
+place as the session continues.
+
+Good for advertising work when the output is easier to *look at* than to read:
+
+- a cross-platform performance scorecard with charts
+- several ad-copy or creative variants laid out side by side for comparison
+- a campaign plan to review before anything spends money
+- an optimization checklist that fills in as you apply changes
+
+**Constraints.** One self-contained page. No backend, no external requests — the CSP blocks scripts,
+fonts, images, `fetch`, XHR, and WebSockets from other hosts, so everything is inlined and images are
+data URIs. No forms that store data, no API calls at view time, no multiple routes. `.html`, `.htm`,
+or `.md`, rendered under 16 MiB.
+
+**Availability.** Pro, Max, Team, or Enterprise, signed in to claude.ai, on the Anthropic API,
+running in the Claude Code CLI or the Claude desktop app. Not on Bedrock, Vertex, or Foundry, and off
+by default in Agent SDK and MCP-server contexts. If Claude can't publish, it says so — fall back to a
+markdown table in the transcript. Don't promise an artifact before you know it worked.
+
+**Privacy.** Private to the author by default. On Team and Enterprise, shareable within the
+organization only; there is no way to share one outside it. That makes artifacts a safe default for
+client ad data.
+
+A styled page costs more output tokens than the same content as text. Prefer SVG or HTML and CSS over
+embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
+inlining every row.
+
+## Claude — scheduled tasks and routines
+
+Claude Desktop's **Routines** page holds two kinds:
+
+- **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
+  and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
+  Desktop starts exactly one catch-up for the most recently missed time. Minimum interval one minute.
+- **Remote routines** run on Anthropic's infrastructure even when the machine is off. Minimum
+  interval one hour.
+
+The user can create either by asking in a Desktop session — "set up a weekly performance review every
+Monday at 9am" — so offer to set it up rather than describing the UI.
+
+**A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
+disapproved ads — create a **remote routine** so it runs with the machine off.
+
+## ChatGPT — sites
+
+Sites lets ChatGPT create, host, and share websites and web apps at a production URL. Unlike an
+artifact, a Site is persistent and can have real storage — a relational database, object storage,
+authentication, environment variables.
+
+Good for advertising work when the user wants something durable and shareable:
+
+- a client-facing performance dashboard an agency updates each week
+- a reporting portal for several brands
+
+**Every Sites deployment URL is a production deployment.** Save a version and review it before
+deploying.
+
+**Privacy — the important one.** A Site can be invitation-only, workspace-wide, or **public to anyone
+with the link**. Ad performance data, spend, customer lists, and lead-form submissions are
+confidential. **Default to invitation-only.** Never publish a Site publicly with a client's account
+data unless the user explicitly says to, and say plainly what would become visible before you do.
+
+If the user wants a one-off visual and not a hosted product, that's a smaller ask than a Site — a
+table or a chart in the conversation is usually right.
+
+## ChatGPT — scheduled tasks
+
+The user can create a task by asking in chat, or from the Scheduled page in the sidebar. Tasks run
+whether or not the user is online, and notify by push and email when they finish.
+
+Three kinds: one-off, recurring, and **monitoring tasks**, which check for changes and notify only
+when there's something meaningful to report. A monitoring task is the natural fit for "tell me if my
+CPA moves" — it re-checks the account and stays quiet until something is worth saying.
+
+**Active-task limits are per plan** — roughly 3 on Go, 5 on Plus, 10 on Business and Edu, 15 on Pro
+and Enterprise. At the limit, a new task can't be created until one is paused, deleted, or completes.
+If creation fails, that's usually why; say so rather than retrying.
+
+## What a scheduled run costs
+
+A scheduled task re-runs the work, which means it calls Adspirer tools again — every run draws on the
+user's monthly tool-call quota exactly like a live conversation. A daily review costs roughly thirty
+times what a monthly one does.
+
+Pick a cadence the plan can carry, and say what it will cost in calls before setting it up. Weekly is
+the right default for a performance review; daily is for accounts spending enough to justify it.
+`get_usage_status` is free and shows what's left.
+
+---
+
+## How to offer, without overselling
+
+1. **Do the work first.** The answer comes before the packaging.
+2. **Offer the surface when it earns its place** — comparison, a chart, something the user will
+   revisit or send to someone.
+3. **Ask before publishing anything that leaves the conversation.** A shared page is outward-facing.
+4. **If the host can't do it, say so once and move on.** A markdown table is a fine answer.

--- a/plugins/chatgpt/adspirer/skills/adspirer-creative/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-creative/SKILL.md
@@ -71,6 +71,20 @@ Fix, in order of leverage:
 Change one variable at a time. Swapping the image *and* the copy *and* the audience teaches you
 nothing about which one mattered.
 
+## Show the variants together
+
+Copy is judged by comparison. Fifteen headlines in a bulleted list all read the same; the same
+fifteen laid out as cards, grouped by angle, with character counts and the truncation point marked,
+are a decision the user can actually make.
+
+
+For a set the user will circulate for approval, offer a **Site** — invitation-only, since it carries
+their unreleased campaign copy. For a quick pick, a table in the conversation is faster than a
+deployment.
+
+Either way, render each variant against its platform's **visible** limit, not the hard one. A Meta
+primary text that looks fine at 2,200 characters is worthless if the offer sits past 125.
+
 ## Applying it
 
 Update in place with `update_ad_headlines`, `update_ad_descriptions`, or `update_ad_content` on
@@ -79,3 +93,7 @@ gathers data — pausing the control before the challenger has proven itself is 
 backwards.
 
 Ads may need review before serving. Say so, rather than letting the user think it's live.
+
+Creative fatigue is a recurring problem, not a one-time fix. Rather than promising to check back,
+offer to schedule a fatigue check on this host — frequency and CTR, every couple of weeks — so the
+next refresh is prompted by the data instead of by someone remembering.

--- a/plugins/chatgpt/adspirer/skills/adspirer-launch/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-launch/SKILL.md
@@ -69,6 +69,23 @@ Then say, plainly:
 **Never resume a campaign you just created without being asked.** Creating and launching are two
 decisions and the second one is the user's.
 
+## Let them see it before it spends
+
+A campaign is a lot of decisions — budget, targeting, bids, creative, extensions — and reading them
+back as prose is how mistakes get approved.
+
+
+If the plan needs sign-off from someone who isn't in this chat, offer a **Site** — invitation-only,
+because it carries budget and strategy. Otherwise summarize it in the conversation before you build.
+
+Once it's live, don't leave it unattended. Offer to schedule a check on this host — a new campaign's
+first week is when it either finds its footing or quietly burns budget, and the user should hear about
+the second before the invoice does. Set it on the metric that defines success: CPA ceiling, ROAS
+floor, daily spend.
+
+
+Each run costs tool calls, so match the cadence to the spend.
+
 ## When the build fails halfway
 
 Say exactly what exists and what doesn't. A campaign with an ad group and no ad is not "created" —

--- a/plugins/chatgpt/adspirer/skills/adspirer-optimize/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-optimize/SKILL.md
@@ -82,3 +82,26 @@ A single-day overspend is not a bug — say so before someone panics.
 After every change, read the object back and confirm it took. Report what actually happened, not
 what you asked for. Tell the user what to expect: a learning period, a dip, a delay before the data
 means anything.
+
+## Don't promise to keep watching — schedule it
+
+Pacing drifts, CPAs creep, and a campaign that was fine on Monday is over budget by Friday. Saying
+"I'll keep an eye on it" is a promise you cannot keep; the conversation ends when the user closes it.
+
+Offer to schedule the check on this host. They can create one just by asking, and it lands with a
+notification wherever they already are.
+
+Use a **monitoring task** rather than a plain recurring one: it re-checks pacing and CPA and stays
+quiet unless something crosses the line, so the user isn't trained to ignore it.
+
+
+Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
+is for accounts where a day of overspend is real money.
+
+If the host has no scheduler, or the user wants the alert to keep firing after they stop using this
+assistant, Adspirer's `monitoring_and_reporting` router runs server-side threshold monitors on ROAS,
+CPA, and spend. `test_monitor` proves one fires before they trust it, and it's free.
+
+
+If the user reviews budget with someone else, offer a **Site** for the proposed split — invitation-only,
+since it exposes spend. Otherwise a table in the conversation is enough.

--- a/plugins/chatgpt/adspirer/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-performance-review/SKILL.md
@@ -71,9 +71,38 @@ and attribute the delta to a cause.
 Before blaming the algorithm, check the boring explanations: a campaign paused, a budget changed, a
 disapproved ad, a landing page that started 404ing, a conversion tag someone removed on deploy.
 
+## Make it easier to look at
+
+A scorecard across six platforms is a table the user will squint at, and a trend is a shape, not a
+column of numbers.
+
+
+Offer a **Site** when the user will revisit it or send it to a client — a hosted dashboard rather
+than a message. Ask first, and default to invitation-only: this page carries their spend and
+conversion data. For a one-off look, a chart in the conversation is enough.
+
+## Make it recurring
+
+A review is worth more every week than once. When the user likes what they just read, offer to
+schedule it — this host can, and they can create it just by asking.
+
+A recurring task re-runs this review and notifies them by push and email. A **monitoring task** is
+better when they'd rather hear only about changes: it re-checks and stays quiet until something
+moves.
+
+
+Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
+right default; daily only for accounts spending enough to justify it. Say so before setting it up.
+
+If the user wants it delivered by **email** instead, or this host has no scheduler, Adspirer's
+`monitoring_and_reporting` router does server-side scheduled briefs. See `references/host-surfaces.md`
+in `adspirer-agent`.
+
 ## Don't
 
 - Don't average CPA across platforms with wildly different volumes and call it "blended performance"
   without saying so.
 - Don't present a 3-day window as a trend.
 - Don't fabricate a number when a tool fails. Say the call failed and which one.
+- Don't schedule a daily review for an account that spends $20 a day. The runs cost more attention,
+  and more quota, than the findings are worth.

--- a/plugins/codex/adspirer/skills/adspirer-agent/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-agent/SKILL.md
@@ -66,6 +66,31 @@ promo that ended. Ask rather than assume.
 The workflow skills stay platform-agnostic. When one of them needs a platform's field rules, load
 that platform's skill.
 
+## Showing work, and repeating work
+
+Do the work first. Packaging comes after the answer, never instead of it.
+
+
+
+**When the user wants something to happen on a schedule, use this host's scheduler.** Offer to set it
+up — they can create one just by asking. Everything they've automated then lives in one place they
+can see, pause, and edit, and the result arrives where they already are.
+
+Good candidates: a Monday performance review, a mid-month pacing check, an alert when CPA passes a
+ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
+
+
+
+Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
+live conversation. Say what the cadence will cost before setting it up — weekly is the right default
+for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.
+
+If this host has no scheduler, or the user wants the report by **email** rather than in a chat,
+Adspirer's `monitoring_and_reporting` router does server-side monitors, scheduled briefs, and
+research jobs. Discovery on it is free: `{"action": "list_tools"}`.
+
+Details, limits, and privacy rules: `references/host-surfaces.md`.
+
 ## Talking about money
 
 Use the account's currency and never silently convert it. Quote budgets as the user said them

--- a/plugins/codex/adspirer/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/codex/adspirer/skills/adspirer-agent/references/host-surfaces.md
@@ -1,0 +1,140 @@
+# Host surfaces: artifacts, sites, and scheduled tasks
+
+Your host may offer ways to show work and repeat work that the terminal or the chat transcript
+can't. Use them when they genuinely fit. Don't announce a capability the host doesn't have.
+
+## Anything recurring: use the host's scheduler when it has one
+
+**If the host can schedule work, schedule it there.** The user gets one place to see, pause, and edit
+everything they've automated, and the result lands where they already are — in the conversation, with
+a notification. Offer to set it up rather than describing the UI; on both hosts the user can create a
+task just by asking.
+
+Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
+competitor's landing page, a nudge before a budget resets.
+
+**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
+worth anything:
+
+- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
+  Nothing to worry about.
+- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
+  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
+  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
+  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
+  one hour.
+
+Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
+today's spend; if it's past 6pm, just summarize what changed."
+
+Adspirer also has its own server-side monitors and email briefs, under the
+`monitoring_and_reporting` router — threshold alerts on ROAS, CPA, spend and CTR, scheduled reports,
+and async research jobs. Reach for those when the host has **no** scheduler at all (a plain CLI), when
+the user wants the report to arrive as **email** rather than in a chat, or when they want an alert to
+keep firing after they stop using this assistant. Otherwise prefer the host.
+
+Discovery on that router is free — `{"action": "list_tools"}` — as are `list_monitors`,
+`list_scheduled_tasks`, `get_monitor_history`, and `test_monitor`.
+
+---
+
+## Claude — artifacts
+
+An artifact is a live page published from the session to a private URL on claude.ai. It updates in
+place as the session continues.
+
+Good for advertising work when the output is easier to *look at* than to read:
+
+- a cross-platform performance scorecard with charts
+- several ad-copy or creative variants laid out side by side for comparison
+- a campaign plan to review before anything spends money
+- an optimization checklist that fills in as you apply changes
+
+**Constraints.** One self-contained page. No backend, no external requests — the CSP blocks scripts,
+fonts, images, `fetch`, XHR, and WebSockets from other hosts, so everything is inlined and images are
+data URIs. No forms that store data, no API calls at view time, no multiple routes. `.html`, `.htm`,
+or `.md`, rendered under 16 MiB.
+
+**Availability.** Pro, Max, Team, or Enterprise, signed in to claude.ai, on the Anthropic API,
+running in the Claude Code CLI or the Claude desktop app. Not on Bedrock, Vertex, or Foundry, and off
+by default in Agent SDK and MCP-server contexts. If Claude can't publish, it says so — fall back to a
+markdown table in the transcript. Don't promise an artifact before you know it worked.
+
+**Privacy.** Private to the author by default. On Team and Enterprise, shareable within the
+organization only; there is no way to share one outside it. That makes artifacts a safe default for
+client ad data.
+
+A styled page costs more output tokens than the same content as text. Prefer SVG or HTML and CSS over
+embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
+inlining every row.
+
+## Claude — scheduled tasks and routines
+
+Claude Desktop's **Routines** page holds two kinds:
+
+- **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
+  and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
+  Desktop starts exactly one catch-up for the most recently missed time. Minimum interval one minute.
+- **Remote routines** run on Anthropic's infrastructure even when the machine is off. Minimum
+  interval one hour.
+
+The user can create either by asking in a Desktop session — "set up a weekly performance review every
+Monday at 9am" — so offer to set it up rather than describing the UI.
+
+**A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
+disapproved ads — create a **remote routine** so it runs with the machine off.
+
+## ChatGPT — sites
+
+Sites lets ChatGPT create, host, and share websites and web apps at a production URL. Unlike an
+artifact, a Site is persistent and can have real storage — a relational database, object storage,
+authentication, environment variables.
+
+Good for advertising work when the user wants something durable and shareable:
+
+- a client-facing performance dashboard an agency updates each week
+- a reporting portal for several brands
+
+**Every Sites deployment URL is a production deployment.** Save a version and review it before
+deploying.
+
+**Privacy — the important one.** A Site can be invitation-only, workspace-wide, or **public to anyone
+with the link**. Ad performance data, spend, customer lists, and lead-form submissions are
+confidential. **Default to invitation-only.** Never publish a Site publicly with a client's account
+data unless the user explicitly says to, and say plainly what would become visible before you do.
+
+If the user wants a one-off visual and not a hosted product, that's a smaller ask than a Site — a
+table or a chart in the conversation is usually right.
+
+## ChatGPT — scheduled tasks
+
+The user can create a task by asking in chat, or from the Scheduled page in the sidebar. Tasks run
+whether or not the user is online, and notify by push and email when they finish.
+
+Three kinds: one-off, recurring, and **monitoring tasks**, which check for changes and notify only
+when there's something meaningful to report. A monitoring task is the natural fit for "tell me if my
+CPA moves" — it re-checks the account and stays quiet until something is worth saying.
+
+**Active-task limits are per plan** — roughly 3 on Go, 5 on Plus, 10 on Business and Edu, 15 on Pro
+and Enterprise. At the limit, a new task can't be created until one is paused, deleted, or completes.
+If creation fails, that's usually why; say so rather than retrying.
+
+## What a scheduled run costs
+
+A scheduled task re-runs the work, which means it calls Adspirer tools again — every run draws on the
+user's monthly tool-call quota exactly like a live conversation. A daily review costs roughly thirty
+times what a monthly one does.
+
+Pick a cadence the plan can carry, and say what it will cost in calls before setting it up. Weekly is
+the right default for a performance review; daily is for accounts spending enough to justify it.
+`get_usage_status` is free and shows what's left.
+
+---
+
+## How to offer, without overselling
+
+1. **Do the work first.** The answer comes before the packaging.
+2. **Offer the surface when it earns its place** — comparison, a chart, something the user will
+   revisit or send to someone.
+3. **Ask before publishing anything that leaves the conversation.** A shared page is outward-facing.
+4. **If the host can't do it, say so once and move on.** A markdown table is a fine answer.

--- a/plugins/codex/adspirer/skills/adspirer-creative/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-creative/SKILL.md
@@ -71,6 +71,17 @@ Fix, in order of leverage:
 Change one variable at a time. Swapping the image *and* the copy *and* the audience teaches you
 nothing about which one mattered.
 
+## Show the variants together
+
+Copy is judged by comparison. Fifteen headlines in a bulleted list all read the same; the same
+fifteen laid out as cards, grouped by angle, with character counts and the truncation point marked,
+are a decision the user can actually make.
+
+
+
+Either way, render each variant against its platform's **visible** limit, not the hard one. A Meta
+primary text that looks fine at 2,200 characters is worthless if the offer sits past 125.
+
 ## Applying it
 
 Update in place with `update_ad_headlines`, `update_ad_descriptions`, or `update_ad_content` on
@@ -79,3 +90,7 @@ gathers data — pausing the control before the challenger has proven itself is 
 backwards.
 
 Ads may need review before serving. Say so, rather than letting the user think it's live.
+
+Creative fatigue is a recurring problem, not a one-time fix. Rather than promising to check back,
+offer to schedule a fatigue check on this host — frequency and CTR, every couple of weeks — so the
+next refresh is prompted by the data instead of by someone remembering.

--- a/plugins/codex/adspirer/skills/adspirer-launch/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-launch/SKILL.md
@@ -69,6 +69,21 @@ Then say, plainly:
 **Never resume a campaign you just created without being asked.** Creating and launching are two
 decisions and the second one is the user's.
 
+## Let them see it before it spends
+
+A campaign is a lot of decisions — budget, targeting, bids, creative, extensions — and reading them
+back as prose is how mistakes get approved.
+
+
+
+Once it's live, don't leave it unattended. Offer to schedule a check on this host — a new campaign's
+first week is when it either finds its footing or quietly burns budget, and the user should hear about
+the second before the invoice does. Set it on the metric that defines success: CPA ceiling, ROAS
+floor, daily spend.
+
+
+Each run costs tool calls, so match the cadence to the spend.
+
 ## When the build fails halfway
 
 Say exactly what exists and what doesn't. A campaign with an ad group and no ad is not "created" —

--- a/plugins/codex/adspirer/skills/adspirer-optimize/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-optimize/SKILL.md
@@ -82,3 +82,20 @@ A single-day overspend is not a bug — say so before someone panics.
 After every change, read the object back and confirm it took. Report what actually happened, not
 what you asked for. Tell the user what to expect: a learning period, a dip, a delay before the data
 means anything.
+
+## Don't promise to keep watching — schedule it
+
+Pacing drifts, CPAs creep, and a campaign that was fine on Monday is over budget by Friday. Saying
+"I'll keep an eye on it" is a promise you cannot keep; the conversation ends when the user closes it.
+
+Offer to schedule the check on this host. They can create one just by asking, and it lands with a
+notification wherever they already are.
+
+
+
+Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
+is for accounts where a day of overspend is real money.
+
+If the host has no scheduler, or the user wants the alert to keep firing after they stop using this
+assistant, Adspirer's `monitoring_and_reporting` router runs server-side threshold monitors on ROAS,
+CPA, and spend. `test_monitor` proves one fires before they trust it, and it's free.

--- a/plugins/codex/adspirer/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-performance-review/SKILL.md
@@ -71,9 +71,32 @@ and attribute the delta to a cause.
 Before blaming the algorithm, check the boring explanations: a campaign paused, a budget changed, a
 disapproved ad, a landing page that started 404ing, a conversion tag someone removed on deploy.
 
+## Make it easier to look at
+
+A scorecard across six platforms is a table the user will squint at, and a trend is a shape, not a
+column of numbers.
+
+
+
+## Make it recurring
+
+A review is worth more every week than once. When the user likes what they just read, offer to
+schedule it — this host can, and they can create it just by asking.
+
+
+
+Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
+right default; daily only for accounts spending enough to justify it. Say so before setting it up.
+
+If the user wants it delivered by **email** instead, or this host has no scheduler, Adspirer's
+`monitoring_and_reporting` router does server-side scheduled briefs. See `references/host-surfaces.md`
+in `adspirer-agent`.
+
 ## Don't
 
 - Don't average CPA across platforms with wildly different volumes and call it "blended performance"
   without saying so.
 - Don't present a 3-day window as a trend.
 - Don't fabricate a number when a tool fails. Say the call failed and which one.
+- Don't schedule a daily review for an account that spends $20 a day. The runs cost more attention,
+  and more quota, than the findings are worth.

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/SKILL.md
@@ -66,6 +66,31 @@ promo that ended. Ask rather than assume.
 The workflow skills stay platform-agnostic. When one of them needs a platform's field rules, load
 that platform's skill.
 
+## Showing work, and repeating work
+
+Do the work first. Packaging comes after the answer, never instead of it.
+
+
+
+**When the user wants something to happen on a schedule, use this host's scheduler.** Offer to set it
+up — they can create one just by asking. Everything they've automated then lives in one place they
+can see, pause, and edit, and the result arrives where they already are.
+
+Good candidates: a Monday performance review, a mid-month pacing check, an alert when CPA passes a
+ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
+
+
+
+Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
+live conversation. Say what the cadence will cost before setting it up — weekly is the right default
+for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.
+
+If this host has no scheduler, or the user wants the report by **email** rather than in a chat,
+Adspirer's `monitoring_and_reporting` router does server-side monitors, scheduled briefs, and
+research jobs. Discovery on it is free: `{"action": "list_tools"}`.
+
+Details, limits, and privacy rules: `references/host-surfaces.md`.
+
 ## Talking about money
 
 Use the account's currency and never silently convert it. Quote budgets as the user said them

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/references/host-surfaces.md
@@ -1,0 +1,140 @@
+# Host surfaces: artifacts, sites, and scheduled tasks
+
+Your host may offer ways to show work and repeat work that the terminal or the chat transcript
+can't. Use them when they genuinely fit. Don't announce a capability the host doesn't have.
+
+## Anything recurring: use the host's scheduler when it has one
+
+**If the host can schedule work, schedule it there.** The user gets one place to see, pause, and edit
+everything they've automated, and the result lands where they already are — in the conversation, with
+a notification. Offer to set it up rather than describing the UI; on both hosts the user can create a
+task just by asking.
+
+Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
+competitor's landing page, a nudge before a budget resets.
+
+**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
+worth anything:
+
+- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
+  Nothing to worry about.
+- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
+  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
+  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
+  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
+  one hour.
+
+Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
+today's spend; if it's past 6pm, just summarize what changed."
+
+Adspirer also has its own server-side monitors and email briefs, under the
+`monitoring_and_reporting` router — threshold alerts on ROAS, CPA, spend and CTR, scheduled reports,
+and async research jobs. Reach for those when the host has **no** scheduler at all (a plain CLI), when
+the user wants the report to arrive as **email** rather than in a chat, or when they want an alert to
+keep firing after they stop using this assistant. Otherwise prefer the host.
+
+Discovery on that router is free — `{"action": "list_tools"}` — as are `list_monitors`,
+`list_scheduled_tasks`, `get_monitor_history`, and `test_monitor`.
+
+---
+
+## Claude — artifacts
+
+An artifact is a live page published from the session to a private URL on claude.ai. It updates in
+place as the session continues.
+
+Good for advertising work when the output is easier to *look at* than to read:
+
+- a cross-platform performance scorecard with charts
+- several ad-copy or creative variants laid out side by side for comparison
+- a campaign plan to review before anything spends money
+- an optimization checklist that fills in as you apply changes
+
+**Constraints.** One self-contained page. No backend, no external requests — the CSP blocks scripts,
+fonts, images, `fetch`, XHR, and WebSockets from other hosts, so everything is inlined and images are
+data URIs. No forms that store data, no API calls at view time, no multiple routes. `.html`, `.htm`,
+or `.md`, rendered under 16 MiB.
+
+**Availability.** Pro, Max, Team, or Enterprise, signed in to claude.ai, on the Anthropic API,
+running in the Claude Code CLI or the Claude desktop app. Not on Bedrock, Vertex, or Foundry, and off
+by default in Agent SDK and MCP-server contexts. If Claude can't publish, it says so — fall back to a
+markdown table in the transcript. Don't promise an artifact before you know it worked.
+
+**Privacy.** Private to the author by default. On Team and Enterprise, shareable within the
+organization only; there is no way to share one outside it. That makes artifacts a safe default for
+client ad data.
+
+A styled page costs more output tokens than the same content as text. Prefer SVG or HTML and CSS over
+embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
+inlining every row.
+
+## Claude — scheduled tasks and routines
+
+Claude Desktop's **Routines** page holds two kinds:
+
+- **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
+  and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
+  Desktop starts exactly one catch-up for the most recently missed time. Minimum interval one minute.
+- **Remote routines** run on Anthropic's infrastructure even when the machine is off. Minimum
+  interval one hour.
+
+The user can create either by asking in a Desktop session — "set up a weekly performance review every
+Monday at 9am" — so offer to set it up rather than describing the UI.
+
+**A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
+disapproved ads — create a **remote routine** so it runs with the machine off.
+
+## ChatGPT — sites
+
+Sites lets ChatGPT create, host, and share websites and web apps at a production URL. Unlike an
+artifact, a Site is persistent and can have real storage — a relational database, object storage,
+authentication, environment variables.
+
+Good for advertising work when the user wants something durable and shareable:
+
+- a client-facing performance dashboard an agency updates each week
+- a reporting portal for several brands
+
+**Every Sites deployment URL is a production deployment.** Save a version and review it before
+deploying.
+
+**Privacy — the important one.** A Site can be invitation-only, workspace-wide, or **public to anyone
+with the link**. Ad performance data, spend, customer lists, and lead-form submissions are
+confidential. **Default to invitation-only.** Never publish a Site publicly with a client's account
+data unless the user explicitly says to, and say plainly what would become visible before you do.
+
+If the user wants a one-off visual and not a hosted product, that's a smaller ask than a Site — a
+table or a chart in the conversation is usually right.
+
+## ChatGPT — scheduled tasks
+
+The user can create a task by asking in chat, or from the Scheduled page in the sidebar. Tasks run
+whether or not the user is online, and notify by push and email when they finish.
+
+Three kinds: one-off, recurring, and **monitoring tasks**, which check for changes and notify only
+when there's something meaningful to report. A monitoring task is the natural fit for "tell me if my
+CPA moves" — it re-checks the account and stays quiet until something is worth saying.
+
+**Active-task limits are per plan** — roughly 3 on Go, 5 on Plus, 10 on Business and Edu, 15 on Pro
+and Enterprise. At the limit, a new task can't be created until one is paused, deleted, or completes.
+If creation fails, that's usually why; say so rather than retrying.
+
+## What a scheduled run costs
+
+A scheduled task re-runs the work, which means it calls Adspirer tools again — every run draws on the
+user's monthly tool-call quota exactly like a live conversation. A daily review costs roughly thirty
+times what a monthly one does.
+
+Pick a cadence the plan can carry, and say what it will cost in calls before setting it up. Weekly is
+the right default for a performance review; daily is for accounts spending enough to justify it.
+`get_usage_status` is free and shows what's left.
+
+---
+
+## How to offer, without overselling
+
+1. **Do the work first.** The answer comes before the packaging.
+2. **Offer the surface when it earns its place** — comparison, a chart, something the user will
+   revisit or send to someone.
+3. **Ask before publishing anything that leaves the conversation.** A shared page is outward-facing.
+4. **If the host can't do it, say so once and move on.** A markdown table is a fine answer.

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-creative/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-creative/SKILL.md
@@ -71,6 +71,17 @@ Fix, in order of leverage:
 Change one variable at a time. Swapping the image *and* the copy *and* the audience teaches you
 nothing about which one mattered.
 
+## Show the variants together
+
+Copy is judged by comparison. Fifteen headlines in a bulleted list all read the same; the same
+fifteen laid out as cards, grouped by angle, with character counts and the truncation point marked,
+are a decision the user can actually make.
+
+
+
+Either way, render each variant against its platform's **visible** limit, not the hard one. A Meta
+primary text that looks fine at 2,200 characters is worthless if the offer sits past 125.
+
 ## Applying it
 
 Update in place with `update_ad_headlines`, `update_ad_descriptions`, or `update_ad_content` on
@@ -79,3 +90,7 @@ gathers data — pausing the control before the challenger has proven itself is 
 backwards.
 
 Ads may need review before serving. Say so, rather than letting the user think it's live.
+
+Creative fatigue is a recurring problem, not a one-time fix. Rather than promising to check back,
+offer to schedule a fatigue check on this host — frequency and CTR, every couple of weeks — so the
+next refresh is prompted by the data instead of by someone remembering.

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-launch/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-launch/SKILL.md
@@ -69,6 +69,21 @@ Then say, plainly:
 **Never resume a campaign you just created without being asked.** Creating and launching are two
 decisions and the second one is the user's.
 
+## Let them see it before it spends
+
+A campaign is a lot of decisions — budget, targeting, bids, creative, extensions — and reading them
+back as prose is how mistakes get approved.
+
+
+
+Once it's live, don't leave it unattended. Offer to schedule a check on this host — a new campaign's
+first week is when it either finds its footing or quietly burns budget, and the user should hear about
+the second before the invoice does. Set it on the metric that defines success: CPA ceiling, ROAS
+floor, daily spend.
+
+
+Each run costs tool calls, so match the cadence to the spend.
+
 ## When the build fails halfway
 
 Say exactly what exists and what doesn't. A campaign with an ad group and no ad is not "created" —

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-optimize/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-optimize/SKILL.md
@@ -82,3 +82,20 @@ A single-day overspend is not a bug — say so before someone panics.
 After every change, read the object back and confirm it took. Report what actually happened, not
 what you asked for. Tell the user what to expect: a learning period, a dip, a delay before the data
 means anything.
+
+## Don't promise to keep watching — schedule it
+
+Pacing drifts, CPAs creep, and a campaign that was fine on Monday is over budget by Friday. Saying
+"I'll keep an eye on it" is a promise you cannot keep; the conversation ends when the user closes it.
+
+Offer to schedule the check on this host. They can create one just by asking, and it lands with a
+notification wherever they already are.
+
+
+
+Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
+is for accounts where a day of overspend is real money.
+
+If the host has no scheduler, or the user wants the alert to keep firing after they stop using this
+assistant, Adspirer's `monitoring_and_reporting` router runs server-side threshold monitors on ROAS,
+CPA, and spend. `test_monitor` proves one fires before they trust it, and it's free.

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-performance-review/SKILL.md
@@ -71,9 +71,32 @@ and attribute the delta to a cause.
 Before blaming the algorithm, check the boring explanations: a campaign paused, a budget changed, a
 disapproved ad, a landing page that started 404ing, a conversion tag someone removed on deploy.
 
+## Make it easier to look at
+
+A scorecard across six platforms is a table the user will squint at, and a trend is a shape, not a
+column of numbers.
+
+
+
+## Make it recurring
+
+A review is worth more every week than once. When the user likes what they just read, offer to
+schedule it — this host can, and they can create it just by asking.
+
+
+
+Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
+right default; daily only for accounts spending enough to justify it. Say so before setting it up.
+
+If the user wants it delivered by **email** instead, or this host has no scheduler, Adspirer's
+`monitoring_and_reporting` router does server-side scheduled briefs. See `references/host-surfaces.md`
+in `adspirer-agent`.
+
 ## Don't
 
 - Don't average CPA across platforms with wildly different volumes and call it "blended performance"
   without saying so.
 - Don't present a 3-day window as a trend.
 - Don't fabricate a number when a tool fails. Say the call failed and which one.
+- Don't schedule a daily review for an account that spends $20 a day. The runs cost more attention,
+  and more quota, than the findings are worth.

--- a/plugins/gemini/skills/adspirer-agent/SKILL.md
+++ b/plugins/gemini/skills/adspirer-agent/SKILL.md
@@ -66,6 +66,31 @@ promo that ended. Ask rather than assume.
 The workflow skills stay platform-agnostic. When one of them needs a platform's field rules, load
 that platform's skill.
 
+## Showing work, and repeating work
+
+Do the work first. Packaging comes after the answer, never instead of it.
+
+
+
+**When the user wants something to happen on a schedule, use this host's scheduler.** Offer to set it
+up — they can create one just by asking. Everything they've automated then lives in one place they
+can see, pause, and edit, and the result arrives where they already are.
+
+Good candidates: a Monday performance review, a mid-month pacing check, an alert when CPA passes a
+ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
+
+
+
+Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
+live conversation. Say what the cadence will cost before setting it up — weekly is the right default
+for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.
+
+If this host has no scheduler, or the user wants the report by **email** rather than in a chat,
+Adspirer's `monitoring_and_reporting` router does server-side monitors, scheduled briefs, and
+research jobs. Discovery on it is free: `{"action": "list_tools"}`.
+
+Details, limits, and privacy rules: `references/host-surfaces.md`.
+
 ## Talking about money
 
 Use the account's currency and never silently convert it. Quote budgets as the user said them

--- a/plugins/gemini/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/gemini/skills/adspirer-agent/references/host-surfaces.md
@@ -1,0 +1,140 @@
+# Host surfaces: artifacts, sites, and scheduled tasks
+
+Your host may offer ways to show work and repeat work that the terminal or the chat transcript
+can't. Use them when they genuinely fit. Don't announce a capability the host doesn't have.
+
+## Anything recurring: use the host's scheduler when it has one
+
+**If the host can schedule work, schedule it there.** The user gets one place to see, pause, and edit
+everything they've automated, and the result lands where they already are — in the conversation, with
+a notification. Offer to set it up rather than describing the UI; on both hosts the user can create a
+task just by asking.
+
+Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
+competitor's landing page, a nudge before a budget resets.
+
+**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
+worth anything:
+
+- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
+  Nothing to worry about.
+- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
+  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
+  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
+  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
+  one hour.
+
+Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
+today's spend; if it's past 6pm, just summarize what changed."
+
+Adspirer also has its own server-side monitors and email briefs, under the
+`monitoring_and_reporting` router — threshold alerts on ROAS, CPA, spend and CTR, scheduled reports,
+and async research jobs. Reach for those when the host has **no** scheduler at all (a plain CLI), when
+the user wants the report to arrive as **email** rather than in a chat, or when they want an alert to
+keep firing after they stop using this assistant. Otherwise prefer the host.
+
+Discovery on that router is free — `{"action": "list_tools"}` — as are `list_monitors`,
+`list_scheduled_tasks`, `get_monitor_history`, and `test_monitor`.
+
+---
+
+## Claude — artifacts
+
+An artifact is a live page published from the session to a private URL on claude.ai. It updates in
+place as the session continues.
+
+Good for advertising work when the output is easier to *look at* than to read:
+
+- a cross-platform performance scorecard with charts
+- several ad-copy or creative variants laid out side by side for comparison
+- a campaign plan to review before anything spends money
+- an optimization checklist that fills in as you apply changes
+
+**Constraints.** One self-contained page. No backend, no external requests — the CSP blocks scripts,
+fonts, images, `fetch`, XHR, and WebSockets from other hosts, so everything is inlined and images are
+data URIs. No forms that store data, no API calls at view time, no multiple routes. `.html`, `.htm`,
+or `.md`, rendered under 16 MiB.
+
+**Availability.** Pro, Max, Team, or Enterprise, signed in to claude.ai, on the Anthropic API,
+running in the Claude Code CLI or the Claude desktop app. Not on Bedrock, Vertex, or Foundry, and off
+by default in Agent SDK and MCP-server contexts. If Claude can't publish, it says so — fall back to a
+markdown table in the transcript. Don't promise an artifact before you know it worked.
+
+**Privacy.** Private to the author by default. On Team and Enterprise, shareable within the
+organization only; there is no way to share one outside it. That makes artifacts a safe default for
+client ad data.
+
+A styled page costs more output tokens than the same content as text. Prefer SVG or HTML and CSS over
+embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
+inlining every row.
+
+## Claude — scheduled tasks and routines
+
+Claude Desktop's **Routines** page holds two kinds:
+
+- **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
+  and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
+  Desktop starts exactly one catch-up for the most recently missed time. Minimum interval one minute.
+- **Remote routines** run on Anthropic's infrastructure even when the machine is off. Minimum
+  interval one hour.
+
+The user can create either by asking in a Desktop session — "set up a weekly performance review every
+Monday at 9am" — so offer to set it up rather than describing the UI.
+
+**A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
+disapproved ads — create a **remote routine** so it runs with the machine off.
+
+## ChatGPT — sites
+
+Sites lets ChatGPT create, host, and share websites and web apps at a production URL. Unlike an
+artifact, a Site is persistent and can have real storage — a relational database, object storage,
+authentication, environment variables.
+
+Good for advertising work when the user wants something durable and shareable:
+
+- a client-facing performance dashboard an agency updates each week
+- a reporting portal for several brands
+
+**Every Sites deployment URL is a production deployment.** Save a version and review it before
+deploying.
+
+**Privacy — the important one.** A Site can be invitation-only, workspace-wide, or **public to anyone
+with the link**. Ad performance data, spend, customer lists, and lead-form submissions are
+confidential. **Default to invitation-only.** Never publish a Site publicly with a client's account
+data unless the user explicitly says to, and say plainly what would become visible before you do.
+
+If the user wants a one-off visual and not a hosted product, that's a smaller ask than a Site — a
+table or a chart in the conversation is usually right.
+
+## ChatGPT — scheduled tasks
+
+The user can create a task by asking in chat, or from the Scheduled page in the sidebar. Tasks run
+whether or not the user is online, and notify by push and email when they finish.
+
+Three kinds: one-off, recurring, and **monitoring tasks**, which check for changes and notify only
+when there's something meaningful to report. A monitoring task is the natural fit for "tell me if my
+CPA moves" — it re-checks the account and stays quiet until something is worth saying.
+
+**Active-task limits are per plan** — roughly 3 on Go, 5 on Plus, 10 on Business and Edu, 15 on Pro
+and Enterprise. At the limit, a new task can't be created until one is paused, deleted, or completes.
+If creation fails, that's usually why; say so rather than retrying.
+
+## What a scheduled run costs
+
+A scheduled task re-runs the work, which means it calls Adspirer tools again — every run draws on the
+user's monthly tool-call quota exactly like a live conversation. A daily review costs roughly thirty
+times what a monthly one does.
+
+Pick a cadence the plan can carry, and say what it will cost in calls before setting it up. Weekly is
+the right default for a performance review; daily is for accounts spending enough to justify it.
+`get_usage_status` is free and shows what's left.
+
+---
+
+## How to offer, without overselling
+
+1. **Do the work first.** The answer comes before the packaging.
+2. **Offer the surface when it earns its place** — comparison, a chart, something the user will
+   revisit or send to someone.
+3. **Ask before publishing anything that leaves the conversation.** A shared page is outward-facing.
+4. **If the host can't do it, say so once and move on.** A markdown table is a fine answer.

--- a/plugins/gemini/skills/adspirer-creative/SKILL.md
+++ b/plugins/gemini/skills/adspirer-creative/SKILL.md
@@ -71,6 +71,17 @@ Fix, in order of leverage:
 Change one variable at a time. Swapping the image *and* the copy *and* the audience teaches you
 nothing about which one mattered.
 
+## Show the variants together
+
+Copy is judged by comparison. Fifteen headlines in a bulleted list all read the same; the same
+fifteen laid out as cards, grouped by angle, with character counts and the truncation point marked,
+are a decision the user can actually make.
+
+
+
+Either way, render each variant against its platform's **visible** limit, not the hard one. A Meta
+primary text that looks fine at 2,200 characters is worthless if the offer sits past 125.
+
 ## Applying it
 
 Update in place with `update_ad_headlines`, `update_ad_descriptions`, or `update_ad_content` on
@@ -79,3 +90,7 @@ gathers data — pausing the control before the challenger has proven itself is 
 backwards.
 
 Ads may need review before serving. Say so, rather than letting the user think it's live.
+
+Creative fatigue is a recurring problem, not a one-time fix. Rather than promising to check back,
+offer to schedule a fatigue check on this host — frequency and CTR, every couple of weeks — so the
+next refresh is prompted by the data instead of by someone remembering.

--- a/plugins/gemini/skills/adspirer-launch/SKILL.md
+++ b/plugins/gemini/skills/adspirer-launch/SKILL.md
@@ -69,6 +69,21 @@ Then say, plainly:
 **Never resume a campaign you just created without being asked.** Creating and launching are two
 decisions and the second one is the user's.
 
+## Let them see it before it spends
+
+A campaign is a lot of decisions — budget, targeting, bids, creative, extensions — and reading them
+back as prose is how mistakes get approved.
+
+
+
+Once it's live, don't leave it unattended. Offer to schedule a check on this host — a new campaign's
+first week is when it either finds its footing or quietly burns budget, and the user should hear about
+the second before the invoice does. Set it on the metric that defines success: CPA ceiling, ROAS
+floor, daily spend.
+
+
+Each run costs tool calls, so match the cadence to the spend.
+
 ## When the build fails halfway
 
 Say exactly what exists and what doesn't. A campaign with an ad group and no ad is not "created" —

--- a/plugins/gemini/skills/adspirer-optimize/SKILL.md
+++ b/plugins/gemini/skills/adspirer-optimize/SKILL.md
@@ -82,3 +82,20 @@ A single-day overspend is not a bug — say so before someone panics.
 After every change, read the object back and confirm it took. Report what actually happened, not
 what you asked for. Tell the user what to expect: a learning period, a dip, a delay before the data
 means anything.
+
+## Don't promise to keep watching — schedule it
+
+Pacing drifts, CPAs creep, and a campaign that was fine on Monday is over budget by Friday. Saying
+"I'll keep an eye on it" is a promise you cannot keep; the conversation ends when the user closes it.
+
+Offer to schedule the check on this host. They can create one just by asking, and it lands with a
+notification wherever they already are.
+
+
+
+Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
+is for accounts where a day of overspend is real money.
+
+If the host has no scheduler, or the user wants the alert to keep firing after they stop using this
+assistant, Adspirer's `monitoring_and_reporting` router runs server-side threshold monitors on ROAS,
+CPA, and spend. `test_monitor` proves one fires before they trust it, and it's free.

--- a/plugins/gemini/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/gemini/skills/adspirer-performance-review/SKILL.md
@@ -71,9 +71,32 @@ and attribute the delta to a cause.
 Before blaming the algorithm, check the boring explanations: a campaign paused, a budget changed, a
 disapproved ad, a landing page that started 404ing, a conversion tag someone removed on deploy.
 
+## Make it easier to look at
+
+A scorecard across six platforms is a table the user will squint at, and a trend is a shape, not a
+column of numbers.
+
+
+
+## Make it recurring
+
+A review is worth more every week than once. When the user likes what they just read, offer to
+schedule it — this host can, and they can create it just by asking.
+
+
+
+Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
+right default; daily only for accounts spending enough to justify it. Say so before setting it up.
+
+If the user wants it delivered by **email** instead, or this host has no scheduler, Adspirer's
+`monitoring_and_reporting` router does server-side scheduled briefs. See `references/host-surfaces.md`
+in `adspirer-agent`.
+
 ## Don't
 
 - Don't average CPA across platforms with wildly different volumes and call it "blended performance"
   without saying so.
 - Don't present a 3-day window as a trend.
 - Don't fabricate a number when a tool fails. Say the call failed and which one.
+- Don't schedule a daily review for an account that spends $20 a day. The runs cost more attention,
+  and more quota, than the findings are worth.

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -9,7 +9,10 @@ set -euo pipefail
 # Each SKILL.md may contain conditional blocks:
 #   <!-- BEGIN:CODEX --> ... <!-- END:CODEX -->
 # A block survives only if its family is in the target's keep-set. Families in use:
-#   CODEX  CURSOR_CLAUDE  CHATGPT  HAS_MEMORY  NO_MEMORY  HAS_FS  NO_FS
+#   CODEX  CURSOR_CLAUDE  CLAUDE  CHATGPT  HAS_MEMORY  NO_MEMORY  HAS_FS  NO_FS
+#
+# CLAUDE is narrower than CURSOR_CLAUDE: artifacts exist in Claude Code and the Claude
+# desktop app, not in Cursor. CHATGPT gates Sites. Cursor/Codex/Gemini get neither.
 #
 # references/ subfolders are copied verbatim — never template-processed.
 
@@ -38,7 +41,7 @@ target_config() {
   case "$1" in
     cursor)  CONTEXT_FILE="BRAND.md";  AUTH="Reconnect via your AI assistant's connector settings"; KEEP="CURSOR_CLAUDE HAS_MEMORY HAS_FS"; WEBSEARCH="yes"; WANT_WORKSPACE="yes" ;;
     codex)   CONTEXT_FILE="AGENTS.md"; AUTH='Run `codex mcp login adspirer` to re-authenticate';     KEEP="CODEX NO_MEMORY HAS_FS";        WEBSEARCH="no";  WANT_WORKSPACE="yes" ;;
-    claude)  CONTEXT_FILE="CLAUDE.md"; AUTH="Reconnect via your AI assistant's connector settings"; KEEP="CURSOR_CLAUDE HAS_MEMORY HAS_FS"; WEBSEARCH="yes"; WANT_WORKSPACE="yes" ;;
+    claude)  CONTEXT_FILE="CLAUDE.md"; AUTH="Reconnect via your AI assistant's connector settings"; KEEP="CURSOR_CLAUDE CLAUDE HAS_MEMORY HAS_FS"; WEBSEARCH="yes"; WANT_WORKSPACE="yes" ;;
     gemini)  CONTEXT_FILE="GEMINI.md"; AUTH="Run the mcp auth command to re-authenticate";          KEEP="CURSOR_CLAUDE NO_MEMORY HAS_FS"; WEBSEARCH="no";  WANT_WORKSPACE="yes" ;;
     chatgpt) CONTEXT_FILE="";          AUTH="Reconnect Adspirer in ChatGPT under Settings then Connectors"; KEEP="CHATGPT NO_MEMORY NO_FS"; WEBSEARCH="no"; WANT_WORKSPACE="no" ;;
     *) echo "unknown target: $1" >&2; return 1 ;;

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -141,6 +141,49 @@ if grep -rEq "$FORBIDDEN" $TARGET_ROOTS 2>/dev/null; then
 else pass; fi
 
 # ---------------------------------------------------------------------------
+# Artifacts are Claude-only; Sites are ChatGPT-only. A skill that advertises the wrong
+# host's surface tells the user to use something that isn't there. references/ are exempt:
+# they ship verbatim to every target and describe all surfaces neutrally.
+echo ""; echo "--- Host surfaces gated to the right target ---"
+
+check "Artifact guidance appears only in the Claude build"
+bad=""
+for root in plugins/chatgpt/adspirer/skills plugins/cursor/adspirer/.cursor/skills plugins/codex/adspirer/skills plugins/gemini/skills; do
+  [ -d "$root" ] || continue
+  hits=$(grep -rlio 'artifact' "$root"/*/SKILL.md 2>/dev/null || true)
+  [ -n "$hits" ] && bad="$bad $hits"
+done
+[ -z "$bad" ] && pass || fail "artifact guidance leaked to a non-Claude target:$bad"
+
+# Case-sensitive word match: the ChatGPT feature is "Site"/"Sites". Bold markers are not a
+# reliable anchor — the source bolds whole sentences, so `**Site**` may never appear.
+SITES_RE='\bSites?\b'
+
+check "Sites guidance appears only in the ChatGPT build"
+bad=""
+for root in skills plugins/cursor/adspirer/.cursor/skills plugins/codex/adspirer/skills plugins/gemini/skills; do
+  [ -d "$root" ] || continue
+  hits=$(grep -rlE "$SITES_RE" "$root"/*/SKILL.md 2>/dev/null || true)
+  [ -n "$hits" ] && bad="$bad $hits"
+done
+[ -z "$bad" ] && pass || fail "Sites guidance leaked to a non-ChatGPT target:$bad"
+
+check "Claude build actually kept its artifact guidance"
+if grep -liq 'artifact' skills/adspirer-agent/SKILL.md 2>/dev/null; then pass; else fail "CLAUDE block was dropped from the claude target"; fi
+
+check "ChatGPT build actually kept its Sites guidance"
+if grep -qE "$SITES_RE" plugins/chatgpt/adspirer/skills/adspirer-agent/SKILL.md 2>/dev/null; then pass; else fail "CHATGPT block was dropped from the chatgpt target"; fi
+
+check "Every host-gated skill kept the right block for its target"
+bad=""
+for s in adspirer-agent adspirer-performance-review adspirer-optimize adspirer-creative adspirer-launch; do
+  f="plugins/chatgpt/adspirer/skills/$s/SKILL.md"
+  [ -f "$f" ] && grep -qi 'artifact' "$f" && bad="$bad chatgpt/$s(artifact)"
+  f="skills/$s/SKILL.md"
+  [ -f "$f" ] && grep -qE "$SITES_RE" "$f" && bad="$bad claude/$s(Sites)"
+done
+[ -z "$bad" ] && pass || fail "wrong host's surface survived:$bad"
+
 echo ""; echo "--- No hardcoded Adspirer pricing ---"
 # Plans and prices change; skills must point at the docs, never carry a number.
 # Ad *budget* examples ($50/day) are fine — this targets Adspirer's own plan prices.

--- a/shared/skills/platform/adspirer-agent/SKILL.md
+++ b/shared/skills/platform/adspirer-agent/SKILL.md
@@ -66,6 +66,59 @@ promo that ended. Ask rather than assume.
 The workflow skills stay platform-agnostic. When one of them needs a platform's field rules, load
 that platform's skill.
 
+## Showing work, and repeating work
+
+Do the work first. Packaging comes after the answer, never instead of it.
+
+<!-- BEGIN:CLAUDE -->
+**When the output is easier to look at than to read, publish an artifact.** A cross-platform
+scorecard with charts, three ad-copy variants side by side, a campaign plan to review before anything
+spends. It's a private page on claude.ai that updates in place as you keep working. Say what you're
+publishing before you do it. If Claude can't publish one, say so once and give a markdown table
+instead — don't promise a link you can't produce.
+<!-- END:CLAUDE -->
+
+<!-- BEGIN:CHATGPT -->
+**When the user wants something durable and shareable, offer a Site.** A client-facing dashboard an
+agency updates weekly, a reporting portal across brands. A Site is hosted at a production URL, so
+treat publishing as an outward-facing act: ask first, and **default to invitation-only**. Ad spend,
+performance, customer lists, and lead-form submissions are confidential — never make them public
+without the user explicitly saying so, and spell out what would become visible before you do.
+
+For a one-off visual, a table or chart in the conversation is usually the right size of answer.
+<!-- END:CHATGPT -->
+
+**When the user wants something to happen on a schedule, use this host's scheduler.** Offer to set it
+up — they can create one just by asking. Everything they've automated then lives in one place they
+can see, pause, and edit, and the result arrives where they already are.
+
+Good candidates: a Monday performance review, a mid-month pacing check, an alert when CPA passes a
+ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
+
+<!-- BEGIN:CHATGPT -->
+ChatGPT tasks run whether or not the user is online and notify by push and email. A **monitoring
+task** is the right shape for "tell me if my CPA moves" — it re-checks and stays quiet until there's
+something worth saying. Active tasks are capped per plan (roughly 3 on Go, 5 on Plus, 15 on Pro), so
+if creation fails, that's usually why.
+<!-- END:CHATGPT -->
+
+<!-- BEGIN:CLAUDE -->
+A **local** Desktop task only fires while the app is open and the machine is awake — a laptop asleep
+at 9am simply skips the run. For anything that matters, create a **remote routine** so it runs with
+the machine off. Write the prompt so a late run behaves: "only look at today's spend; if it's past
+6pm, just summarize what changed."
+<!-- END:CLAUDE -->
+
+Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
+live conversation. Say what the cadence will cost before setting it up — weekly is the right default
+for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.
+
+If this host has no scheduler, or the user wants the report by **email** rather than in a chat,
+Adspirer's `monitoring_and_reporting` router does server-side monitors, scheduled briefs, and
+research jobs. Discovery on it is free: `{"action": "list_tools"}`.
+
+Details, limits, and privacy rules: `references/host-surfaces.md`.
+
 ## Talking about money
 
 Use the account's currency and never silently convert it. Quote budgets as the user said them

--- a/shared/skills/platform/adspirer-agent/references/host-surfaces.md
+++ b/shared/skills/platform/adspirer-agent/references/host-surfaces.md
@@ -1,0 +1,140 @@
+# Host surfaces: artifacts, sites, and scheduled tasks
+
+Your host may offer ways to show work and repeat work that the terminal or the chat transcript
+can't. Use them when they genuinely fit. Don't announce a capability the host doesn't have.
+
+## Anything recurring: use the host's scheduler when it has one
+
+**If the host can schedule work, schedule it there.** The user gets one place to see, pause, and edit
+everything they've automated, and the result lands where they already are — in the conversation, with
+a notification. Offer to set it up rather than describing the UI; on both hosts the user can create a
+task just by asking.
+
+Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
+competitor's landing page, a nudge before a budget resets.
+
+**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
+worth anything:
+
+- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
+  Nothing to worry about.
+- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
+  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
+  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
+  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
+  one hour.
+
+Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
+today's spend; if it's past 6pm, just summarize what changed."
+
+Adspirer also has its own server-side monitors and email briefs, under the
+`monitoring_and_reporting` router — threshold alerts on ROAS, CPA, spend and CTR, scheduled reports,
+and async research jobs. Reach for those when the host has **no** scheduler at all (a plain CLI), when
+the user wants the report to arrive as **email** rather than in a chat, or when they want an alert to
+keep firing after they stop using this assistant. Otherwise prefer the host.
+
+Discovery on that router is free — `{"action": "list_tools"}` — as are `list_monitors`,
+`list_scheduled_tasks`, `get_monitor_history`, and `test_monitor`.
+
+---
+
+## Claude — artifacts
+
+An artifact is a live page published from the session to a private URL on claude.ai. It updates in
+place as the session continues.
+
+Good for advertising work when the output is easier to *look at* than to read:
+
+- a cross-platform performance scorecard with charts
+- several ad-copy or creative variants laid out side by side for comparison
+- a campaign plan to review before anything spends money
+- an optimization checklist that fills in as you apply changes
+
+**Constraints.** One self-contained page. No backend, no external requests — the CSP blocks scripts,
+fonts, images, `fetch`, XHR, and WebSockets from other hosts, so everything is inlined and images are
+data URIs. No forms that store data, no API calls at view time, no multiple routes. `.html`, `.htm`,
+or `.md`, rendered under 16 MiB.
+
+**Availability.** Pro, Max, Team, or Enterprise, signed in to claude.ai, on the Anthropic API,
+running in the Claude Code CLI or the Claude desktop app. Not on Bedrock, Vertex, or Foundry, and off
+by default in Agent SDK and MCP-server contexts. If Claude can't publish, it says so — fall back to a
+markdown table in the transcript. Don't promise an artifact before you know it worked.
+
+**Privacy.** Private to the author by default. On Team and Enterprise, shareable within the
+organization only; there is no way to share one outside it. That makes artifacts a safe default for
+client ad data.
+
+A styled page costs more output tokens than the same content as text. Prefer SVG or HTML and CSS over
+embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
+inlining every row.
+
+## Claude — scheduled tasks and routines
+
+Claude Desktop's **Routines** page holds two kinds:
+
+- **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
+  and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
+  Desktop starts exactly one catch-up for the most recently missed time. Minimum interval one minute.
+- **Remote routines** run on Anthropic's infrastructure even when the machine is off. Minimum
+  interval one hour.
+
+The user can create either by asking in a Desktop session — "set up a weekly performance review every
+Monday at 9am" — so offer to set it up rather than describing the UI.
+
+**A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
+disapproved ads — create a **remote routine** so it runs with the machine off.
+
+## ChatGPT — sites
+
+Sites lets ChatGPT create, host, and share websites and web apps at a production URL. Unlike an
+artifact, a Site is persistent and can have real storage — a relational database, object storage,
+authentication, environment variables.
+
+Good for advertising work when the user wants something durable and shareable:
+
+- a client-facing performance dashboard an agency updates each week
+- a reporting portal for several brands
+
+**Every Sites deployment URL is a production deployment.** Save a version and review it before
+deploying.
+
+**Privacy — the important one.** A Site can be invitation-only, workspace-wide, or **public to anyone
+with the link**. Ad performance data, spend, customer lists, and lead-form submissions are
+confidential. **Default to invitation-only.** Never publish a Site publicly with a client's account
+data unless the user explicitly says to, and say plainly what would become visible before you do.
+
+If the user wants a one-off visual and not a hosted product, that's a smaller ask than a Site — a
+table or a chart in the conversation is usually right.
+
+## ChatGPT — scheduled tasks
+
+The user can create a task by asking in chat, or from the Scheduled page in the sidebar. Tasks run
+whether or not the user is online, and notify by push and email when they finish.
+
+Three kinds: one-off, recurring, and **monitoring tasks**, which check for changes and notify only
+when there's something meaningful to report. A monitoring task is the natural fit for "tell me if my
+CPA moves" — it re-checks the account and stays quiet until something is worth saying.
+
+**Active-task limits are per plan** — roughly 3 on Go, 5 on Plus, 10 on Business and Edu, 15 on Pro
+and Enterprise. At the limit, a new task can't be created until one is paused, deleted, or completes.
+If creation fails, that's usually why; say so rather than retrying.
+
+## What a scheduled run costs
+
+A scheduled task re-runs the work, which means it calls Adspirer tools again — every run draws on the
+user's monthly tool-call quota exactly like a live conversation. A daily review costs roughly thirty
+times what a monthly one does.
+
+Pick a cadence the plan can carry, and say what it will cost in calls before setting it up. Weekly is
+the right default for a performance review; daily is for accounts spending enough to justify it.
+`get_usage_status` is free and shows what's left.
+
+---
+
+## How to offer, without overselling
+
+1. **Do the work first.** The answer comes before the packaging.
+2. **Offer the surface when it earns its place** — comparison, a chart, something the user will
+   revisit or send to someone.
+3. **Ask before publishing anything that leaves the conversation.** A shared page is outward-facing.
+4. **If the host can't do it, say so once and move on.** A markdown table is a fine answer.

--- a/shared/skills/platform/adspirer-creative/SKILL.md
+++ b/shared/skills/platform/adspirer-creative/SKILL.md
@@ -71,6 +71,27 @@ Fix, in order of leverage:
 Change one variable at a time. Swapping the image *and* the copy *and* the audience teaches you
 nothing about which one mattered.
 
+## Show the variants together
+
+Copy is judged by comparison. Fifteen headlines in a bulleted list all read the same; the same
+fifteen laid out as cards, grouped by angle, with character counts and the truncation point marked,
+are a decision the user can actually make.
+
+<!-- BEGIN:CLAUDE -->
+Publish an **artifact**: variants side by side, each rendered at its real character limit so
+truncation is visible, with a one-line note on the angle each one takes. For a fatigue refresh, show
+the current ad next to its replacements.
+<!-- END:CLAUDE -->
+
+<!-- BEGIN:CHATGPT -->
+For a set the user will circulate for approval, offer a **Site** — invitation-only, since it carries
+their unreleased campaign copy. For a quick pick, a table in the conversation is faster than a
+deployment.
+<!-- END:CHATGPT -->
+
+Either way, render each variant against its platform's **visible** limit, not the hard one. A Meta
+primary text that looks fine at 2,200 characters is worthless if the offer sits past 125.
+
 ## Applying it
 
 Update in place with `update_ad_headlines`, `update_ad_descriptions`, or `update_ad_content` on
@@ -79,3 +100,11 @@ gathers data — pausing the control before the challenger has proven itself is 
 backwards.
 
 Ads may need review before serving. Say so, rather than letting the user think it's live.
+
+Creative fatigue is a recurring problem, not a one-time fix. Rather than promising to check back,
+offer to schedule a fatigue check on this host — frequency and CTR, every couple of weeks — so the
+next refresh is prompted by the data instead of by someone remembering.
+
+<!-- BEGIN:CLAUDE -->
+A **remote routine** beats a local Desktop task here; fatigue doesn't wait for the laptop to be open.
+<!-- END:CLAUDE -->

--- a/shared/skills/platform/adspirer-launch/SKILL.md
+++ b/shared/skills/platform/adspirer-launch/SKILL.md
@@ -69,6 +69,34 @@ Then say, plainly:
 **Never resume a campaign you just created without being asked.** Creating and launching are two
 decisions and the second one is the user's.
 
+## Let them see it before it spends
+
+A campaign is a lot of decisions — budget, targeting, bids, creative, extensions — and reading them
+back as prose is how mistakes get approved.
+
+<!-- BEGIN:CLAUDE -->
+Before you create anything, publish the plan as an **artifact**: structure, daily and monthly spend,
+targeting, the creative, and what's still missing. It's much easier to catch "that's the wrong
+landing page" on a page than in a paragraph. Republish it after the build with what actually landed.
+<!-- END:CLAUDE -->
+
+<!-- BEGIN:CHATGPT -->
+If the plan needs sign-off from someone who isn't in this chat, offer a **Site** — invitation-only,
+because it carries budget and strategy. Otherwise summarize it in the conversation before you build.
+<!-- END:CHATGPT -->
+
+Once it's live, don't leave it unattended. Offer to schedule a check on this host — a new campaign's
+first week is when it either finds its footing or quietly burns budget, and the user should hear about
+the second before the invoice does. Set it on the metric that defines success: CPA ceiling, ROAS
+floor, daily spend.
+
+<!-- BEGIN:CLAUDE -->
+Make it a **remote routine** rather than a local Desktop task, so a sleeping laptop doesn't skip the
+day the campaign went wrong.
+<!-- END:CLAUDE -->
+
+Each run costs tool calls, so match the cadence to the spend.
+
 ## When the build fails halfway
 
 Say exactly what exists and what doesn't. A campaign with an ad group and no ad is not "created" —

--- a/shared/skills/platform/adspirer-optimize/SKILL.md
+++ b/shared/skills/platform/adspirer-optimize/SKILL.md
@@ -82,3 +82,38 @@ A single-day overspend is not a bug — say so before someone panics.
 After every change, read the object back and confirm it took. Report what actually happened, not
 what you asked for. Tell the user what to expect: a learning period, a dip, a delay before the data
 means anything.
+
+## Don't promise to keep watching — schedule it
+
+Pacing drifts, CPAs creep, and a campaign that was fine on Monday is over budget by Friday. Saying
+"I'll keep an eye on it" is a promise you cannot keep; the conversation ends when the user closes it.
+
+Offer to schedule the check on this host. They can create one just by asking, and it lands with a
+notification wherever they already are.
+
+<!-- BEGIN:CHATGPT -->
+Use a **monitoring task** rather than a plain recurring one: it re-checks pacing and CPA and stays
+quiet unless something crosses the line, so the user isn't trained to ignore it.
+<!-- END:CHATGPT -->
+
+<!-- BEGIN:CLAUDE -->
+Use a **remote routine**, not a local Desktop task. A local task is skipped whenever the machine is
+asleep — and the overspend you're watching for does not wait for the laptop to open.
+<!-- END:CLAUDE -->
+
+Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
+is for accounts where a day of overspend is real money.
+
+If the host has no scheduler, or the user wants the alert to keep firing after they stop using this
+assistant, Adspirer's `monitoring_and_reporting` router runs server-side threshold monitors on ROAS,
+CPA, and spend. `test_monitor` proves one fires before they trust it, and it's free.
+
+<!-- BEGIN:CLAUDE -->
+For the reallocation itself, an **artifact** makes the trade legible: current split beside proposed
+split, CPA per campaign, and the projected change. Easier to approve, and easier to refuse.
+<!-- END:CLAUDE -->
+
+<!-- BEGIN:CHATGPT -->
+If the user reviews budget with someone else, offer a **Site** for the proposed split — invitation-only,
+since it exposes spend. Otherwise a table in the conversation is enough.
+<!-- END:CHATGPT -->

--- a/shared/skills/platform/adspirer-performance-review/SKILL.md
+++ b/shared/skills/platform/adspirer-performance-review/SKILL.md
@@ -71,9 +71,51 @@ and attribute the delta to a cause.
 Before blaming the algorithm, check the boring explanations: a campaign paused, a budget changed, a
 disapproved ad, a landing page that started 404ing, a conversion tag someone removed on deploy.
 
+## Make it easier to look at
+
+A scorecard across six platforms is a table the user will squint at, and a trend is a shape, not a
+column of numbers.
+
+<!-- BEGIN:CLAUDE -->
+Offer an **artifact**: platform cards, a spend-vs-conversions chart, the anomalies called out. It's a
+private page that updates in place, so a weekly review can republish to the same URL instead of
+scrolling back through the transcript. Keep charts as SVG or CSS rather than embedded images.
+<!-- END:CLAUDE -->
+
+<!-- BEGIN:CHATGPT -->
+Offer a **Site** when the user will revisit it or send it to a client — a hosted dashboard rather
+than a message. Ask first, and default to invitation-only: this page carries their spend and
+conversion data. For a one-off look, a chart in the conversation is enough.
+<!-- END:CHATGPT -->
+
+## Make it recurring
+
+A review is worth more every week than once. When the user likes what they just read, offer to
+schedule it — this host can, and they can create it just by asking.
+
+<!-- BEGIN:CHATGPT -->
+A recurring task re-runs this review and notifies them by push and email. A **monitoring task** is
+better when they'd rather hear only about changes: it re-checks and stays quiet until something
+moves.
+<!-- END:CHATGPT -->
+
+<!-- BEGIN:CLAUDE -->
+Prefer a **remote routine** over a local Desktop task — a local one is skipped whenever the machine
+is asleep at the scheduled hour, which is exactly when a Monday-morning review would fire.
+<!-- END:CLAUDE -->
+
+Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
+right default; daily only for accounts spending enough to justify it. Say so before setting it up.
+
+If the user wants it delivered by **email** instead, or this host has no scheduler, Adspirer's
+`monitoring_and_reporting` router does server-side scheduled briefs. See `references/host-surfaces.md`
+in `adspirer-agent`.
+
 ## Don't
 
 - Don't average CPA across platforms with wildly different volumes and call it "blended performance"
   without saying so.
 - Don't present a 3-day window as a trend.
 - Don't fabricate a number when a tool fails. Say the call failed and which one.
+- Don't schedule a daily review for an account that spends $20 a day. The runs cost more attention,
+  and more quota, than the findings are worth.

--- a/skills/adspirer-agent/SKILL.md
+++ b/skills/adspirer-agent/SKILL.md
@@ -66,6 +66,40 @@ promo that ended. Ask rather than assume.
 The workflow skills stay platform-agnostic. When one of them needs a platform's field rules, load
 that platform's skill.
 
+## Showing work, and repeating work
+
+Do the work first. Packaging comes after the answer, never instead of it.
+
+**When the output is easier to look at than to read, publish an artifact.** A cross-platform
+scorecard with charts, three ad-copy variants side by side, a campaign plan to review before anything
+spends. It's a private page on claude.ai that updates in place as you keep working. Say what you're
+publishing before you do it. If Claude can't publish one, say so once and give a markdown table
+instead — don't promise a link you can't produce.
+
+
+**When the user wants something to happen on a schedule, use this host's scheduler.** Offer to set it
+up — they can create one just by asking. Everything they've automated then lives in one place they
+can see, pause, and edit, and the result arrives where they already are.
+
+Good candidates: a Monday performance review, a mid-month pacing check, an alert when CPA passes a
+ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
+
+
+A **local** Desktop task only fires while the app is open and the machine is awake — a laptop asleep
+at 9am simply skips the run. For anything that matters, create a **remote routine** so it runs with
+the machine off. Write the prompt so a late run behaves: "only look at today's spend; if it's past
+6pm, just summarize what changed."
+
+Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
+live conversation. Say what the cadence will cost before setting it up — weekly is the right default
+for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.
+
+If this host has no scheduler, or the user wants the report by **email** rather than in a chat,
+Adspirer's `monitoring_and_reporting` router does server-side monitors, scheduled briefs, and
+research jobs. Discovery on it is free: `{"action": "list_tools"}`.
+
+Details, limits, and privacy rules: `references/host-surfaces.md`.
+
 ## Talking about money
 
 Use the account's currency and never silently convert it. Quote budgets as the user said them

--- a/skills/adspirer-agent/references/host-surfaces.md
+++ b/skills/adspirer-agent/references/host-surfaces.md
@@ -1,0 +1,140 @@
+# Host surfaces: artifacts, sites, and scheduled tasks
+
+Your host may offer ways to show work and repeat work that the terminal or the chat transcript
+can't. Use them when they genuinely fit. Don't announce a capability the host doesn't have.
+
+## Anything recurring: use the host's scheduler when it has one
+
+**If the host can schedule work, schedule it there.** The user gets one place to see, pause, and edit
+everything they've automated, and the result lands where they already are — in the conversation, with
+a notification. Offer to set it up rather than describing the UI; on both hosts the user can create a
+task just by asking.
+
+Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
+competitor's landing page, a nudge before a budget resets.
+
+**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
+worth anything:
+
+- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
+  Nothing to worry about.
+- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
+  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
+  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
+  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
+  one hour.
+
+Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
+today's spend; if it's past 6pm, just summarize what changed."
+
+Adspirer also has its own server-side monitors and email briefs, under the
+`monitoring_and_reporting` router — threshold alerts on ROAS, CPA, spend and CTR, scheduled reports,
+and async research jobs. Reach for those when the host has **no** scheduler at all (a plain CLI), when
+the user wants the report to arrive as **email** rather than in a chat, or when they want an alert to
+keep firing after they stop using this assistant. Otherwise prefer the host.
+
+Discovery on that router is free — `{"action": "list_tools"}` — as are `list_monitors`,
+`list_scheduled_tasks`, `get_monitor_history`, and `test_monitor`.
+
+---
+
+## Claude — artifacts
+
+An artifact is a live page published from the session to a private URL on claude.ai. It updates in
+place as the session continues.
+
+Good for advertising work when the output is easier to *look at* than to read:
+
+- a cross-platform performance scorecard with charts
+- several ad-copy or creative variants laid out side by side for comparison
+- a campaign plan to review before anything spends money
+- an optimization checklist that fills in as you apply changes
+
+**Constraints.** One self-contained page. No backend, no external requests — the CSP blocks scripts,
+fonts, images, `fetch`, XHR, and WebSockets from other hosts, so everything is inlined and images are
+data URIs. No forms that store data, no API calls at view time, no multiple routes. `.html`, `.htm`,
+or `.md`, rendered under 16 MiB.
+
+**Availability.** Pro, Max, Team, or Enterprise, signed in to claude.ai, on the Anthropic API,
+running in the Claude Code CLI or the Claude desktop app. Not on Bedrock, Vertex, or Foundry, and off
+by default in Agent SDK and MCP-server contexts. If Claude can't publish, it says so — fall back to a
+markdown table in the transcript. Don't promise an artifact before you know it worked.
+
+**Privacy.** Private to the author by default. On Team and Enterprise, shareable within the
+organization only; there is no way to share one outside it. That makes artifacts a safe default for
+client ad data.
+
+A styled page costs more output tokens than the same content as text. Prefer SVG or HTML and CSS over
+embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
+inlining every row.
+
+## Claude — scheduled tasks and routines
+
+Claude Desktop's **Routines** page holds two kinds:
+
+- **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
+  and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
+  Desktop starts exactly one catch-up for the most recently missed time. Minimum interval one minute.
+- **Remote routines** run on Anthropic's infrastructure even when the machine is off. Minimum
+  interval one hour.
+
+The user can create either by asking in a Desktop session — "set up a weekly performance review every
+Monday at 9am" — so offer to set it up rather than describing the UI.
+
+**A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
+disapproved ads — create a **remote routine** so it runs with the machine off.
+
+## ChatGPT — sites
+
+Sites lets ChatGPT create, host, and share websites and web apps at a production URL. Unlike an
+artifact, a Site is persistent and can have real storage — a relational database, object storage,
+authentication, environment variables.
+
+Good for advertising work when the user wants something durable and shareable:
+
+- a client-facing performance dashboard an agency updates each week
+- a reporting portal for several brands
+
+**Every Sites deployment URL is a production deployment.** Save a version and review it before
+deploying.
+
+**Privacy — the important one.** A Site can be invitation-only, workspace-wide, or **public to anyone
+with the link**. Ad performance data, spend, customer lists, and lead-form submissions are
+confidential. **Default to invitation-only.** Never publish a Site publicly with a client's account
+data unless the user explicitly says to, and say plainly what would become visible before you do.
+
+If the user wants a one-off visual and not a hosted product, that's a smaller ask than a Site — a
+table or a chart in the conversation is usually right.
+
+## ChatGPT — scheduled tasks
+
+The user can create a task by asking in chat, or from the Scheduled page in the sidebar. Tasks run
+whether or not the user is online, and notify by push and email when they finish.
+
+Three kinds: one-off, recurring, and **monitoring tasks**, which check for changes and notify only
+when there's something meaningful to report. A monitoring task is the natural fit for "tell me if my
+CPA moves" — it re-checks the account and stays quiet until something is worth saying.
+
+**Active-task limits are per plan** — roughly 3 on Go, 5 on Plus, 10 on Business and Edu, 15 on Pro
+and Enterprise. At the limit, a new task can't be created until one is paused, deleted, or completes.
+If creation fails, that's usually why; say so rather than retrying.
+
+## What a scheduled run costs
+
+A scheduled task re-runs the work, which means it calls Adspirer tools again — every run draws on the
+user's monthly tool-call quota exactly like a live conversation. A daily review costs roughly thirty
+times what a monthly one does.
+
+Pick a cadence the plan can carry, and say what it will cost in calls before setting it up. Weekly is
+the right default for a performance review; daily is for accounts spending enough to justify it.
+`get_usage_status` is free and shows what's left.
+
+---
+
+## How to offer, without overselling
+
+1. **Do the work first.** The answer comes before the packaging.
+2. **Offer the surface when it earns its place** — comparison, a chart, something the user will
+   revisit or send to someone.
+3. **Ask before publishing anything that leaves the conversation.** A shared page is outward-facing.
+4. **If the host can't do it, say so once and move on.** A markdown table is a fine answer.

--- a/skills/adspirer-creative/SKILL.md
+++ b/skills/adspirer-creative/SKILL.md
@@ -71,6 +71,20 @@ Fix, in order of leverage:
 Change one variable at a time. Swapping the image *and* the copy *and* the audience teaches you
 nothing about which one mattered.
 
+## Show the variants together
+
+Copy is judged by comparison. Fifteen headlines in a bulleted list all read the same; the same
+fifteen laid out as cards, grouped by angle, with character counts and the truncation point marked,
+are a decision the user can actually make.
+
+Publish an **artifact**: variants side by side, each rendered at its real character limit so
+truncation is visible, with a one-line note on the angle each one takes. For a fatigue refresh, show
+the current ad next to its replacements.
+
+
+Either way, render each variant against its platform's **visible** limit, not the hard one. A Meta
+primary text that looks fine at 2,200 characters is worthless if the offer sits past 125.
+
 ## Applying it
 
 Update in place with `update_ad_headlines`, `update_ad_descriptions`, or `update_ad_content` on
@@ -79,3 +93,9 @@ gathers data — pausing the control before the challenger has proven itself is 
 backwards.
 
 Ads may need review before serving. Say so, rather than letting the user think it's live.
+
+Creative fatigue is a recurring problem, not a one-time fix. Rather than promising to check back,
+offer to schedule a fatigue check on this host — frequency and CTR, every couple of weeks — so the
+next refresh is prompted by the data instead of by someone remembering.
+
+A **remote routine** beats a local Desktop task here; fatigue doesn't wait for the laptop to be open.

--- a/skills/adspirer-launch/SKILL.md
+++ b/skills/adspirer-launch/SKILL.md
@@ -69,6 +69,26 @@ Then say, plainly:
 **Never resume a campaign you just created without being asked.** Creating and launching are two
 decisions and the second one is the user's.
 
+## Let them see it before it spends
+
+A campaign is a lot of decisions — budget, targeting, bids, creative, extensions — and reading them
+back as prose is how mistakes get approved.
+
+Before you create anything, publish the plan as an **artifact**: structure, daily and monthly spend,
+targeting, the creative, and what's still missing. It's much easier to catch "that's the wrong
+landing page" on a page than in a paragraph. Republish it after the build with what actually landed.
+
+
+Once it's live, don't leave it unattended. Offer to schedule a check on this host — a new campaign's
+first week is when it either finds its footing or quietly burns budget, and the user should hear about
+the second before the invoice does. Set it on the metric that defines success: CPA ceiling, ROAS
+floor, daily spend.
+
+Make it a **remote routine** rather than a local Desktop task, so a sleeping laptop doesn't skip the
+day the campaign went wrong.
+
+Each run costs tool calls, so match the cadence to the spend.
+
 ## When the build fails halfway
 
 Say exactly what exists and what doesn't. A campaign with an ad group and no ad is not "created" —

--- a/skills/adspirer-optimize/SKILL.md
+++ b/skills/adspirer-optimize/SKILL.md
@@ -82,3 +82,25 @@ A single-day overspend is not a bug — say so before someone panics.
 After every change, read the object back and confirm it took. Report what actually happened, not
 what you asked for. Tell the user what to expect: a learning period, a dip, a delay before the data
 means anything.
+
+## Don't promise to keep watching — schedule it
+
+Pacing drifts, CPAs creep, and a campaign that was fine on Monday is over budget by Friday. Saying
+"I'll keep an eye on it" is a promise you cannot keep; the conversation ends when the user closes it.
+
+Offer to schedule the check on this host. They can create one just by asking, and it lands with a
+notification wherever they already are.
+
+
+Use a **remote routine**, not a local Desktop task. A local task is skipped whenever the machine is
+asleep — and the overspend you're watching for does not wait for the laptop to open.
+
+Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
+is for accounts where a day of overspend is real money.
+
+If the host has no scheduler, or the user wants the alert to keep firing after they stop using this
+assistant, Adspirer's `monitoring_and_reporting` router runs server-side threshold monitors on ROAS,
+CPA, and spend. `test_monitor` proves one fires before they trust it, and it's free.
+
+For the reallocation itself, an **artifact** makes the trade legible: current split beside proposed
+split, CPA per campaign, and the projected change. Easier to approve, and easier to refuse.

--- a/skills/adspirer-performance-review/SKILL.md
+++ b/skills/adspirer-performance-review/SKILL.md
@@ -71,9 +71,37 @@ and attribute the delta to a cause.
 Before blaming the algorithm, check the boring explanations: a campaign paused, a budget changed, a
 disapproved ad, a landing page that started 404ing, a conversion tag someone removed on deploy.
 
+## Make it easier to look at
+
+A scorecard across six platforms is a table the user will squint at, and a trend is a shape, not a
+column of numbers.
+
+Offer an **artifact**: platform cards, a spend-vs-conversions chart, the anomalies called out. It's a
+private page that updates in place, so a weekly review can republish to the same URL instead of
+scrolling back through the transcript. Keep charts as SVG or CSS rather than embedded images.
+
+
+## Make it recurring
+
+A review is worth more every week than once. When the user likes what they just read, offer to
+schedule it — this host can, and they can create it just by asking.
+
+
+Prefer a **remote routine** over a local Desktop task — a local one is skipped whenever the machine
+is asleep at the scheduled hour, which is exactly when a Monday-morning review would fire.
+
+Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
+right default; daily only for accounts spending enough to justify it. Say so before setting it up.
+
+If the user wants it delivered by **email** instead, or this host has no scheduler, Adspirer's
+`monitoring_and_reporting` router does server-side scheduled briefs. See `references/host-surfaces.md`
+in `adspirer-agent`.
+
 ## Don't
 
 - Don't average CPA across platforms with wildly different volumes and call it "blended performance"
   without saying so.
 - Don't present a 3-day window as a trend.
 - Don't fabricate a number when a tool fails. Say the call failed and which one.
+- Don't schedule a daily review for an account that spends $20 a day. The runs cost more attention,
+  and more quota, than the findings are worth.


### PR DESCRIPTION
## Why

The skills only ever produced terminal text, and never offered to repeat work — even though every
host we ship to can do both.

## What

| Host | Gets |
|---|---|
| Claude | **artifacts** (private page on claude.ai), **remote routines** |
| ChatGPT | **Sites** (hosted, production URL), **scheduled + monitoring tasks** |
| Cursor / Codex / Gemini | neither; falls back to Adspirer's `monitoring_and_reporting` |

Gated with a new `CLAUDE` conditional-block family — narrower than `CURSOR_CLAUDE`, because artifacts
exist in Claude Code and the desktop app but **not** in Cursor. No skill advertises a surface its host
doesn't have.

**Prefer the host's scheduler.** It's robust, the user gets one place to manage everything they've
automated, and a scheduled run re-invokes our tools like any other conversation. Adspirer's own
monitors remain the fallback for hosts with no scheduler, and for users who want the report by email.

## Two facts the guidance has to carry, or it's wrong

- **Claude Desktop *local* tasks only fire while the app is open and the machine is awake.** A laptop
  asleep at 9am silently skips the run. So the skills steer to a **remote routine** for anything that
  matters — pacing, spend spikes, a new campaign's first week.
- **ChatGPT caps active tasks per plan** (~3 Go / 5 Plus / 15 Pro). If creation fails, that's usually
  why. Say so rather than retrying.

Also: a scheduled run **costs tool calls** against the user's monthly quota. The skills state what a
cadence will cost before setting one up — weekly for a review, daily only where the spend earns it.

## Privacy

A Site can be made **public**. Ad spend, performance, customer lists and lead-form submissions are
confidential, so the skills default to **invitation-only** and require the user to say otherwise,
spelling out what would become visible. Artifacts are private by default and cannot be shared outside
the organization, which makes them the safe default on Claude.

## Where each surface earns its place

- `performance-review` — the scorecard as a page; schedule the weekly review
- `creative` — variants side by side, rendered at the **visible** character limit so truncation shows
- `optimize` — the proposed budget split; schedule the pacing check
- `launch` — the plan reviewed before anything spends; watch the first week

## Lints

New checks assert artifacts appear only in the Claude build, Sites only in the ChatGPT build, and that
neither block was silently dropped from the target that needs it.

My first Sites lint keyed on `**Site**` and **passed vacuously** — the source bolds whole sentences,
so that literal never appears. It now matches the word. Worth noting: a lint that can't fail is worse
than no lint.

`./scripts/validate.sh` → **112/112**. Discovery budget unchanged at 3,939 chars — all of this loads
on activation, not at discovery.

Detail, limits and availability live in `adspirer-agent/references/host-surfaces.md`, which ships
verbatim to every target and describes all surfaces neutrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LiDsW9XF3Y6k17a6mCFSv