### PR TITLE
fix(skills): correct each host's scheduler name, and add Codex

### DIFF
--- a/plugins/chatgpt/adspirer/skills/adspirer-agent/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-agent/SKILL.md
@@ -86,10 +86,11 @@ can see, pause, and edit, and the result arrives where they already are.
 Good candidates: a Monday performance review, a mid-month pacing check, an alert when CPA passes a
 ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
 
-ChatGPT tasks run whether or not the user is online and notify by push and email. A **monitoring
-task** is the right shape for "tell me if my CPA moves" — it re-checks and stays quiet until there's
-something worth saying. Active tasks are capped per plan (roughly 3 on Go, 5 on Plus, 15 on Pro), so
-if creation fails, that's usually why.
+ChatGPT calls them **scheduled tasks**. They run whether or not the user is online and notify by push
+and email. A **monitoring task** is the right shape for "tell me if my CPA moves" — it re-checks and
+stays quiet until there's something worth saying. Active tasks are capped per plan (roughly 3 on Go,
+5 on Plus, 15 on Pro), so if creation fails, that's usually why.
+
 
 
 Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a

--- a/plugins/chatgpt/adspirer/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-agent/references/host-surfaces.md
@@ -13,16 +13,24 @@ task just by asking.
 Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
 competitor's landing page, a nudge before a budget resets.
 
-**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
-worth anything:
+### What each host calls it
 
-- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
-  Nothing to worry about.
-- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
-  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
-  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
-  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
-  one hour.
+| Host | Feature | Runs when the machine is off? |
+|---|---|---|
+| ChatGPT | **Scheduled tasks** | Yes |
+| Codex | **Scheduled tasks** (automations) | Yes |
+| Claude Cowork | **Scheduled tasks**, via the `/schedule` skill | Yes — they run remotely |
+| Claude Code | **Routines** — *local* task or *remote* routine | Local: **no**. Remote: yes |
+
+**The one that bites: a Claude Code *local* Desktop task only fires while the app is open and the
+computer is awake.** A machine that sleeps through 9am skips the run; on wake, Desktop starts exactly
+one catch-up for the most recently missed time and discards anything older. For spend, pacing, or
+disapprovals, create a **remote routine** instead — Anthropic's infrastructure, machine off, minimum
+interval one hour.
+
+Cowork's scheduled tasks do *not* have this problem. They run remotely on their cadence even with the
+computer asleep or the app closed, and they can use connected tools, skills, and installed plugins —
+including this one. Available on Pro, Max, Team, and Enterprise.
 
 Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
 today's spend; if it's past 6pm, just summarize what changed."
@@ -68,9 +76,9 @@ A styled page costs more output tokens than the same content as text. Prefer SVG
 embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
 inlining every row.
 
-## Claude — scheduled tasks and routines
+## Claude Code — routines
 
-Claude Desktop's **Routines** page holds two kinds:
+Claude Code Desktop's **Routines** page holds two kinds:
 
 - **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
   and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
@@ -83,6 +91,37 @@ Monday at 9am" — so offer to set it up rather than describing the UI.
 
 **A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
 disapproved ads — create a **remote routine** so it runs with the machine off.
+
+`/loop` is a third option, but it lives only inside the current session and dies with it. Fine for
+polling something for the next ten minutes; useless for a Monday report.
+
+## Claude Cowork — scheduled tasks
+
+Created with the `/schedule` skill from any chat, or from **Scheduled** in the sidebar. Cadences:
+hourly, daily, weekly, weekdays, or on demand.
+
+They **run remotely**, on their cadence, even when the computer is asleep or the Claude Desktop app is
+closed — so unlike a Claude Code local task, there's no reliability caveat. They have the same
+capabilities as a normal Cowork task, including connected tools, skills, and installed plugins.
+
+Available on Pro, Max, Team, and Enterprise.
+
+## Codex — scheduled tasks (automations)
+
+The user creates one by asking inside a Codex task — describing the work, the cadence, and whether
+each run continues the existing task or starts fresh — or from the **Scheduled** view.
+
+That view is also the **inbox**: each run's findings land there with an unread indicator, and a run
+with nothing to report can archive itself. Cadence can be a minute-based interval for a tight
+follow-up loop, a daily or weekly time, or a custom RRULE.
+
+Runs are unattended and inherit the sandbox settings already in force, so they execute without
+approval prompts where policy allows. Be conservative about what you schedule: an unattended run that
+writes to an ad account spends real money without anyone watching.
+
+**Codex hooks are not a scheduler.** They are event handlers — `SessionStart`, `PreToolUse`,
+`PostToolUse`, `Stop` — configured by the user for their own environment. Never offer a hook as a way
+to run a recurring report.
 
 ## ChatGPT — sites
 

--- a/plugins/chatgpt/adspirer/skills/adspirer-optimize/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-optimize/SKILL.md
@@ -95,6 +95,7 @@ Use a **monitoring task** rather than a plain recurring one: it re-checks pacing
 quiet unless something crosses the line, so the user isn't trained to ignore it.
 
 
+
 Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
 is for accounts where a day of overspend is real money.
 

--- a/plugins/chatgpt/adspirer/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/chatgpt/adspirer/skills/adspirer-performance-review/SKILL.md
@@ -91,6 +91,7 @@ better when they'd rather hear only about changes: it re-checks and stays quiet 
 moves.
 
 
+
 Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
 right default; daily only for accounts spending enough to justify it. Say so before setting it up.
 

--- a/plugins/codex/adspirer/skills/adspirer-agent/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-agent/SKILL.md
@@ -81,6 +81,18 @@ ceiling, a watch on a competitor's landing page, a reminder before budgets reset
 
 
 
+Codex calls them **scheduled tasks** (also "automations"). The user creates one by asking in a Codex
+task — describe the work, the cadence, and whether each run continues the existing task or starts
+fresh — or from the **Scheduled** view, which doubles as the inbox where each run's findings land
+with an unread marker.
+
+Cadence can be a minute interval, daily or weekly at a time, or a custom RRULE. Runs are unattended
+under the sandbox settings already in force.
+
+Codex **hooks** are a different thing: event handlers that fire on `SessionStart`, `PostToolUse` and
+the like. They are the user's own configuration, not a scheduler. Never offer a hook for a recurring
+report.
+
 Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
 live conversation. Say what the cadence will cost before setting it up — weekly is the right default
 for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.

--- a/plugins/codex/adspirer/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/codex/adspirer/skills/adspirer-agent/references/host-surfaces.md
@@ -13,16 +13,24 @@ task just by asking.
 Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
 competitor's landing page, a nudge before a budget resets.
 
-**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
-worth anything:
+### What each host calls it
 
-- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
-  Nothing to worry about.
-- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
-  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
-  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
-  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
-  one hour.
+| Host | Feature | Runs when the machine is off? |
+|---|---|---|
+| ChatGPT | **Scheduled tasks** | Yes |
+| Codex | **Scheduled tasks** (automations) | Yes |
+| Claude Cowork | **Scheduled tasks**, via the `/schedule` skill | Yes — they run remotely |
+| Claude Code | **Routines** — *local* task or *remote* routine | Local: **no**. Remote: yes |
+
+**The one that bites: a Claude Code *local* Desktop task only fires while the app is open and the
+computer is awake.** A machine that sleeps through 9am skips the run; on wake, Desktop starts exactly
+one catch-up for the most recently missed time and discards anything older. For spend, pacing, or
+disapprovals, create a **remote routine** instead — Anthropic's infrastructure, machine off, minimum
+interval one hour.
+
+Cowork's scheduled tasks do *not* have this problem. They run remotely on their cadence even with the
+computer asleep or the app closed, and they can use connected tools, skills, and installed plugins —
+including this one. Available on Pro, Max, Team, and Enterprise.
 
 Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
 today's spend; if it's past 6pm, just summarize what changed."
@@ -68,9 +76,9 @@ A styled page costs more output tokens than the same content as text. Prefer SVG
 embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
 inlining every row.
 
-## Claude — scheduled tasks and routines
+## Claude Code — routines
 
-Claude Desktop's **Routines** page holds two kinds:
+Claude Code Desktop's **Routines** page holds two kinds:
 
 - **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
   and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
@@ -83,6 +91,37 @@ Monday at 9am" — so offer to set it up rather than describing the UI.
 
 **A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
 disapproved ads — create a **remote routine** so it runs with the machine off.
+
+`/loop` is a third option, but it lives only inside the current session and dies with it. Fine for
+polling something for the next ten minutes; useless for a Monday report.
+
+## Claude Cowork — scheduled tasks
+
+Created with the `/schedule` skill from any chat, or from **Scheduled** in the sidebar. Cadences:
+hourly, daily, weekly, weekdays, or on demand.
+
+They **run remotely**, on their cadence, even when the computer is asleep or the Claude Desktop app is
+closed — so unlike a Claude Code local task, there's no reliability caveat. They have the same
+capabilities as a normal Cowork task, including connected tools, skills, and installed plugins.
+
+Available on Pro, Max, Team, and Enterprise.
+
+## Codex — scheduled tasks (automations)
+
+The user creates one by asking inside a Codex task — describing the work, the cadence, and whether
+each run continues the existing task or starts fresh — or from the **Scheduled** view.
+
+That view is also the **inbox**: each run's findings land there with an unread indicator, and a run
+with nothing to report can archive itself. Cadence can be a minute-based interval for a tight
+follow-up loop, a daily or weekly time, or a custom RRULE.
+
+Runs are unattended and inherit the sandbox settings already in force, so they execute without
+approval prompts where policy allows. Be conservative about what you schedule: an unattended run that
+writes to an ad account spends real money without anyone watching.
+
+**Codex hooks are not a scheduler.** They are event handlers — `SessionStart`, `PreToolUse`,
+`PostToolUse`, `Stop` — configured by the user for their own environment. Never offer a hook as a way
+to run a recurring report.
 
 ## ChatGPT — sites
 

--- a/plugins/codex/adspirer/skills/adspirer-optimize/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-optimize/SKILL.md
@@ -93,6 +93,10 @@ notification wherever they already are.
 
 
 
+A Codex **scheduled task** works here, and a run that finds nothing archives itself — so the user only
+hears from it when pacing has actually drifted. Keep it read-only: an unattended run that changes
+budgets spends real money with nobody watching.
+
 Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
 is for accounts where a day of overspend is real money.
 

--- a/plugins/codex/adspirer/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/codex/adspirer/skills/adspirer-performance-review/SKILL.md
@@ -85,6 +85,10 @@ schedule it — this host can, and they can create it just by asking.
 
 
 
+Codex calls it a **scheduled task**. Each run's findings land in the **Scheduled** inbox with an
+unread marker, and a run with nothing worth reporting archives itself — which suits a weekly review
+that's often uneventful.
+
 Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
 right default; daily only for accounts spending enough to justify it. Say so before setting it up.
 

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/SKILL.md
@@ -81,6 +81,7 @@ ceiling, a watch on a competitor's landing page, a reminder before budgets reset
 
 
 
+
 Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
 live conversation. Say what the cadence will cost before setting it up — weekly is the right default
 for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-agent/references/host-surfaces.md
@@ -13,16 +13,24 @@ task just by asking.
 Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
 competitor's landing page, a nudge before a budget resets.
 
-**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
-worth anything:
+### What each host calls it
 
-- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
-  Nothing to worry about.
-- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
-  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
-  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
-  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
-  one hour.
+| Host | Feature | Runs when the machine is off? |
+|---|---|---|
+| ChatGPT | **Scheduled tasks** | Yes |
+| Codex | **Scheduled tasks** (automations) | Yes |
+| Claude Cowork | **Scheduled tasks**, via the `/schedule` skill | Yes — they run remotely |
+| Claude Code | **Routines** — *local* task or *remote* routine | Local: **no**. Remote: yes |
+
+**The one that bites: a Claude Code *local* Desktop task only fires while the app is open and the
+computer is awake.** A machine that sleeps through 9am skips the run; on wake, Desktop starts exactly
+one catch-up for the most recently missed time and discards anything older. For spend, pacing, or
+disapprovals, create a **remote routine** instead — Anthropic's infrastructure, machine off, minimum
+interval one hour.
+
+Cowork's scheduled tasks do *not* have this problem. They run remotely on their cadence even with the
+computer asleep or the app closed, and they can use connected tools, skills, and installed plugins —
+including this one. Available on Pro, Max, Team, and Enterprise.
 
 Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
 today's spend; if it's past 6pm, just summarize what changed."
@@ -68,9 +76,9 @@ A styled page costs more output tokens than the same content as text. Prefer SVG
 embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
 inlining every row.
 
-## Claude — scheduled tasks and routines
+## Claude Code — routines
 
-Claude Desktop's **Routines** page holds two kinds:
+Claude Code Desktop's **Routines** page holds two kinds:
 
 - **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
   and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
@@ -83,6 +91,37 @@ Monday at 9am" — so offer to set it up rather than describing the UI.
 
 **A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
 disapproved ads — create a **remote routine** so it runs with the machine off.
+
+`/loop` is a third option, but it lives only inside the current session and dies with it. Fine for
+polling something for the next ten minutes; useless for a Monday report.
+
+## Claude Cowork — scheduled tasks
+
+Created with the `/schedule` skill from any chat, or from **Scheduled** in the sidebar. Cadences:
+hourly, daily, weekly, weekdays, or on demand.
+
+They **run remotely**, on their cadence, even when the computer is asleep or the Claude Desktop app is
+closed — so unlike a Claude Code local task, there's no reliability caveat. They have the same
+capabilities as a normal Cowork task, including connected tools, skills, and installed plugins.
+
+Available on Pro, Max, Team, and Enterprise.
+
+## Codex — scheduled tasks (automations)
+
+The user creates one by asking inside a Codex task — describing the work, the cadence, and whether
+each run continues the existing task or starts fresh — or from the **Scheduled** view.
+
+That view is also the **inbox**: each run's findings land there with an unread indicator, and a run
+with nothing to report can archive itself. Cadence can be a minute-based interval for a tight
+follow-up loop, a daily or weekly time, or a custom RRULE.
+
+Runs are unattended and inherit the sandbox settings already in force, so they execute without
+approval prompts where policy allows. Be conservative about what you schedule: an unattended run that
+writes to an ad account spends real money without anyone watching.
+
+**Codex hooks are not a scheduler.** They are event handlers — `SessionStart`, `PreToolUse`,
+`PostToolUse`, `Stop` — configured by the user for their own environment. Never offer a hook as a way
+to run a recurring report.
 
 ## ChatGPT — sites
 

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-optimize/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-optimize/SKILL.md
@@ -93,6 +93,7 @@ notification wherever they already are.
 
 
 
+
 Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
 is for accounts where a day of overspend is real money.
 

--- a/plugins/cursor/adspirer/.cursor/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/cursor/adspirer/.cursor/skills/adspirer-performance-review/SKILL.md
@@ -85,6 +85,7 @@ schedule it — this host can, and they can create it just by asking.
 
 
 
+
 Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
 right default; daily only for accounts spending enough to justify it. Say so before setting it up.
 

--- a/plugins/gemini/skills/adspirer-agent/SKILL.md
+++ b/plugins/gemini/skills/adspirer-agent/SKILL.md
@@ -81,6 +81,7 @@ ceiling, a watch on a competitor's landing page, a reminder before budgets reset
 
 
 
+
 Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
 live conversation. Say what the cadence will cost before setting it up — weekly is the right default
 for a review; daily is for accounts spending enough to earn it. `get_usage_status` is free.

--- a/plugins/gemini/skills/adspirer-agent/references/host-surfaces.md
+++ b/plugins/gemini/skills/adspirer-agent/references/host-surfaces.md
@@ -13,16 +13,24 @@ task just by asking.
 Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
 competitor's landing page, a nudge before a budget resets.
 
-**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
-worth anything:
+### What each host calls it
 
-- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
-  Nothing to worry about.
-- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
-  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
-  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
-  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
-  one hour.
+| Host | Feature | Runs when the machine is off? |
+|---|---|---|
+| ChatGPT | **Scheduled tasks** | Yes |
+| Codex | **Scheduled tasks** (automations) | Yes |
+| Claude Cowork | **Scheduled tasks**, via the `/schedule` skill | Yes — they run remotely |
+| Claude Code | **Routines** — *local* task or *remote* routine | Local: **no**. Remote: yes |
+
+**The one that bites: a Claude Code *local* Desktop task only fires while the app is open and the
+computer is awake.** A machine that sleeps through 9am skips the run; on wake, Desktop starts exactly
+one catch-up for the most recently missed time and discards anything older. For spend, pacing, or
+disapprovals, create a **remote routine** instead — Anthropic's infrastructure, machine off, minimum
+interval one hour.
+
+Cowork's scheduled tasks do *not* have this problem. They run remotely on their cadence even with the
+computer asleep or the app closed, and they can use connected tools, skills, and installed plugins —
+including this one. Available on Pro, Max, Team, and Enterprise.
 
 Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
 today's spend; if it's past 6pm, just summarize what changed."
@@ -68,9 +76,9 @@ A styled page costs more output tokens than the same content as text. Prefer SVG
 embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
 inlining every row.
 
-## Claude — scheduled tasks and routines
+## Claude Code — routines
 
-Claude Desktop's **Routines** page holds two kinds:
+Claude Code Desktop's **Routines** page holds two kinds:
 
 - **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
   and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
@@ -83,6 +91,37 @@ Monday at 9am" — so offer to set it up rather than describing the UI.
 
 **A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
 disapproved ads — create a **remote routine** so it runs with the machine off.
+
+`/loop` is a third option, but it lives only inside the current session and dies with it. Fine for
+polling something for the next ten minutes; useless for a Monday report.
+
+## Claude Cowork — scheduled tasks
+
+Created with the `/schedule` skill from any chat, or from **Scheduled** in the sidebar. Cadences:
+hourly, daily, weekly, weekdays, or on demand.
+
+They **run remotely**, on their cadence, even when the computer is asleep or the Claude Desktop app is
+closed — so unlike a Claude Code local task, there's no reliability caveat. They have the same
+capabilities as a normal Cowork task, including connected tools, skills, and installed plugins.
+
+Available on Pro, Max, Team, and Enterprise.
+
+## Codex — scheduled tasks (automations)
+
+The user creates one by asking inside a Codex task — describing the work, the cadence, and whether
+each run continues the existing task or starts fresh — or from the **Scheduled** view.
+
+That view is also the **inbox**: each run's findings land there with an unread indicator, and a run
+with nothing to report can archive itself. Cadence can be a minute-based interval for a tight
+follow-up loop, a daily or weekly time, or a custom RRULE.
+
+Runs are unattended and inherit the sandbox settings already in force, so they execute without
+approval prompts where policy allows. Be conservative about what you schedule: an unattended run that
+writes to an ad account spends real money without anyone watching.
+
+**Codex hooks are not a scheduler.** They are event handlers — `SessionStart`, `PreToolUse`,
+`PostToolUse`, `Stop` — configured by the user for their own environment. Never offer a hook as a way
+to run a recurring report.
 
 ## ChatGPT — sites
 

--- a/plugins/gemini/skills/adspirer-optimize/SKILL.md
+++ b/plugins/gemini/skills/adspirer-optimize/SKILL.md
@@ -93,6 +93,7 @@ notification wherever they already are.
 
 
 
+
 Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
 is for accounts where a day of overspend is real money.
 

--- a/plugins/gemini/skills/adspirer-performance-review/SKILL.md
+++ b/plugins/gemini/skills/adspirer-performance-review/SKILL.md
@@ -85,6 +85,7 @@ schedule it — this host can, and they can create it just by asking.
 
 
 
+
 Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
 right default; daily only for accounts spending enough to justify it. Say so before setting it up.
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -174,6 +174,17 @@ if grep -liq 'artifact' skills/adspirer-agent/SKILL.md 2>/dev/null; then pass; e
 check "ChatGPT build actually kept its Sites guidance"
 if grep -qE "$SITES_RE" plugins/chatgpt/adspirer/skills/adspirer-agent/SKILL.md 2>/dev/null; then pass; else fail "CHATGPT block was dropped from the chatgpt target"; fi
 
+check "Codex build kept its scheduled-tasks guidance"
+if grep -qi 'scheduled task' plugins/codex/adspirer/skills/adspirer-agent/SKILL.md 2>/dev/null; then pass; else fail "CODEX block was dropped from the codex target"; fi
+
+# Codex hooks are event handlers, not a scheduler. Flag a line that pairs them with recurring
+# work — unless the line is telling the agent NOT to (the skill says so explicitly).
+check "Codex build never offers hooks as a scheduler"
+if grep -hiE 'hook.{0,40}(recurring|schedule|report)' plugins/codex/adspirer/skills/*/SKILL.md 2>/dev/null \
+   | grep -qivE 'never|not a scheduler|do not|don.t'; then
+  fail "a hook is being offered as a scheduling mechanism"
+else pass; fi
+
 check "Every host-gated skill kept the right block for its target"
 bad=""
 for s in adspirer-agent adspirer-performance-review adspirer-optimize adspirer-creative adspirer-launch; do

--- a/shared/skills/platform/adspirer-agent/SKILL.md
+++ b/shared/skills/platform/adspirer-agent/SKILL.md
@@ -96,18 +96,39 @@ Good candidates: a Monday performance review, a mid-month pacing check, an alert
 ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
 
 <!-- BEGIN:CHATGPT -->
-ChatGPT tasks run whether or not the user is online and notify by push and email. A **monitoring
-task** is the right shape for "tell me if my CPA moves" — it re-checks and stays quiet until there's
-something worth saying. Active tasks are capped per plan (roughly 3 on Go, 5 on Plus, 15 on Pro), so
-if creation fails, that's usually why.
+ChatGPT calls them **scheduled tasks**. They run whether or not the user is online and notify by push
+and email. A **monitoring task** is the right shape for "tell me if my CPA moves" — it re-checks and
+stays quiet until there's something worth saying. Active tasks are capped per plan (roughly 3 on Go,
+5 on Plus, 15 on Pro), so if creation fails, that's usually why.
 <!-- END:CHATGPT -->
 
 <!-- BEGIN:CLAUDE -->
-A **local** Desktop task only fires while the app is open and the machine is awake — a laptop asleep
-at 9am simply skips the run. For anything that matters, create a **remote routine** so it runs with
-the machine off. Write the prompt so a late run behaves: "only look at today's spend; if it's past
-6pm, just summarize what changed."
+The name depends on where you're running:
+
+- **Claude Cowork** — a **scheduled task**, created with the `/schedule` skill from any chat. These
+  run remotely, on their cadence, even with the computer asleep or the app closed. Hourly, daily,
+  weekly, weekdays, or on demand. Paid plans only.
+- **Claude Code** — a **routine**. A *local* Desktop task only fires while the app is open and the
+  machine is awake, so a laptop asleep at 9am silently skips the run. Prefer a **remote routine** for
+  anything that matters; it runs on Anthropic's infrastructure with the machine off.
+
+Write the prompt so a late run behaves: "only look at today's spend; if it's past 6pm, just summarize
+what changed."
 <!-- END:CLAUDE -->
+
+<!-- BEGIN:CODEX -->
+Codex calls them **scheduled tasks** (also "automations"). The user creates one by asking in a Codex
+task — describe the work, the cadence, and whether each run continues the existing task or starts
+fresh — or from the **Scheduled** view, which doubles as the inbox where each run's findings land
+with an unread marker.
+
+Cadence can be a minute interval, daily or weekly at a time, or a custom RRULE. Runs are unattended
+under the sandbox settings already in force.
+
+Codex **hooks** are a different thing: event handlers that fire on `SessionStart`, `PostToolUse` and
+the like. They are the user's own configuration, not a scheduler. Never offer a hook for a recurring
+report.
+<!-- END:CODEX -->
 
 Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
 live conversation. Say what the cadence will cost before setting it up — weekly is the right default

--- a/shared/skills/platform/adspirer-agent/references/host-surfaces.md
+++ b/shared/skills/platform/adspirer-agent/references/host-surfaces.md
@@ -13,16 +13,24 @@ task just by asking.
 Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
 competitor's landing page, a nudge before a budget resets.
 
-**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
-worth anything:
+### What each host calls it
 
-- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
-  Nothing to worry about.
-- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
-  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
-  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
-  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
-  one hour.
+| Host | Feature | Runs when the machine is off? |
+|---|---|---|
+| ChatGPT | **Scheduled tasks** | Yes |
+| Codex | **Scheduled tasks** (automations) | Yes |
+| Claude Cowork | **Scheduled tasks**, via the `/schedule` skill | Yes — they run remotely |
+| Claude Code | **Routines** — *local* task or *remote* routine | Local: **no**. Remote: yes |
+
+**The one that bites: a Claude Code *local* Desktop task only fires while the app is open and the
+computer is awake.** A machine that sleeps through 9am skips the run; on wake, Desktop starts exactly
+one catch-up for the most recently missed time and discards anything older. For spend, pacing, or
+disapprovals, create a **remote routine** instead — Anthropic's infrastructure, machine off, minimum
+interval one hour.
+
+Cowork's scheduled tasks do *not* have this problem. They run remotely on their cadence even with the
+computer asleep or the app closed, and they can use connected tools, skills, and installed plugins —
+including this one. Available on Pro, Max, Team, and Enterprise.
 
 Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
 today's spend; if it's past 6pm, just summarize what changed."
@@ -68,9 +76,9 @@ A styled page costs more output tokens than the same content as text. Prefer SVG
 embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
 inlining every row.
 
-## Claude — scheduled tasks and routines
+## Claude Code — routines
 
-Claude Desktop's **Routines** page holds two kinds:
+Claude Code Desktop's **Routines** page holds two kinds:
 
 - **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
   and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
@@ -83,6 +91,37 @@ Monday at 9am" — so offer to set it up rather than describing the UI.
 
 **A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
 disapproved ads — create a **remote routine** so it runs with the machine off.
+
+`/loop` is a third option, but it lives only inside the current session and dies with it. Fine for
+polling something for the next ten minutes; useless for a Monday report.
+
+## Claude Cowork — scheduled tasks
+
+Created with the `/schedule` skill from any chat, or from **Scheduled** in the sidebar. Cadences:
+hourly, daily, weekly, weekdays, or on demand.
+
+They **run remotely**, on their cadence, even when the computer is asleep or the Claude Desktop app is
+closed — so unlike a Claude Code local task, there's no reliability caveat. They have the same
+capabilities as a normal Cowork task, including connected tools, skills, and installed plugins.
+
+Available on Pro, Max, Team, and Enterprise.
+
+## Codex — scheduled tasks (automations)
+
+The user creates one by asking inside a Codex task — describing the work, the cadence, and whether
+each run continues the existing task or starts fresh — or from the **Scheduled** view.
+
+That view is also the **inbox**: each run's findings land there with an unread indicator, and a run
+with nothing to report can archive itself. Cadence can be a minute-based interval for a tight
+follow-up loop, a daily or weekly time, or a custom RRULE.
+
+Runs are unattended and inherit the sandbox settings already in force, so they execute without
+approval prompts where policy allows. Be conservative about what you schedule: an unattended run that
+writes to an ad account spends real money without anyone watching.
+
+**Codex hooks are not a scheduler.** They are event handlers — `SessionStart`, `PreToolUse`,
+`PostToolUse`, `Stop` — configured by the user for their own environment. Never offer a hook as a way
+to run a recurring report.
 
 ## ChatGPT — sites
 

--- a/shared/skills/platform/adspirer-creative/SKILL.md
+++ b/shared/skills/platform/adspirer-creative/SKILL.md
@@ -106,5 +106,6 @@ offer to schedule a fatigue check on this host — frequency and CTR, every coup
 next refresh is prompted by the data instead of by someone remembering.
 
 <!-- BEGIN:CLAUDE -->
-A **remote routine** beats a local Desktop task here; fatigue doesn't wait for the laptop to be open.
+A Cowork **scheduled task**, or a **remote routine** in Claude Code — not a local Desktop task.
+Fatigue doesn't wait for the laptop to be open.
 <!-- END:CLAUDE -->

--- a/shared/skills/platform/adspirer-launch/SKILL.md
+++ b/shared/skills/platform/adspirer-launch/SKILL.md
@@ -91,8 +91,8 @@ the second before the invoice does. Set it on the metric that defines success: C
 floor, daily spend.
 
 <!-- BEGIN:CLAUDE -->
-Make it a **remote routine** rather than a local Desktop task, so a sleeping laptop doesn't skip the
-day the campaign went wrong.
+A Cowork **scheduled task** runs remotely; in Claude Code make it a **remote routine** rather than a
+local Desktop task, so a sleeping laptop doesn't skip the day the campaign went wrong.
 <!-- END:CLAUDE -->
 
 Each run costs tool calls, so match the cadence to the spend.

--- a/shared/skills/platform/adspirer-optimize/SKILL.md
+++ b/shared/skills/platform/adspirer-optimize/SKILL.md
@@ -97,9 +97,16 @@ quiet unless something crosses the line, so the user isn't trained to ignore it.
 <!-- END:CHATGPT -->
 
 <!-- BEGIN:CLAUDE -->
-Use a **remote routine**, not a local Desktop task. A local task is skipped whenever the machine is
-asleep — and the overspend you're watching for does not wait for the laptop to open.
+In Cowork, a **scheduled task** (`/schedule`) — it runs remotely. In Claude Code, a **remote
+routine**, not a local Desktop task: a local one is skipped whenever the machine is asleep, and the
+overspend you're watching for does not wait for the laptop to open.
 <!-- END:CLAUDE -->
+
+<!-- BEGIN:CODEX -->
+A Codex **scheduled task** works here, and a run that finds nothing archives itself — so the user only
+hears from it when pacing has actually drifted. Keep it read-only: an unattended run that changes
+budgets spends real money with nobody watching.
+<!-- END:CODEX -->
 
 Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
 is for accounts where a day of overspend is real money.

--- a/shared/skills/platform/adspirer-performance-review/SKILL.md
+++ b/shared/skills/platform/adspirer-performance-review/SKILL.md
@@ -100,9 +100,17 @@ moves.
 <!-- END:CHATGPT -->
 
 <!-- BEGIN:CLAUDE -->
-Prefer a **remote routine** over a local Desktop task — a local one is skipped whenever the machine
-is asleep at the scheduled hour, which is exactly when a Monday-morning review would fire.
+In Cowork, that's a **scheduled task** via `/schedule` — it runs remotely, so a sleeping laptop
+doesn't matter. In Claude Code, it's a **routine**; prefer a *remote* one, because a local Desktop
+task is skipped whenever the machine is asleep at the scheduled hour — exactly when a Monday-morning
+review would fire.
 <!-- END:CLAUDE -->
+
+<!-- BEGIN:CODEX -->
+Codex calls it a **scheduled task**. Each run's findings land in the **Scheduled** inbox with an
+unread marker, and a run with nothing worth reporting archives itself — which suits a weekly review
+that's often uneventful.
+<!-- END:CODEX -->
 
 Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
 right default; daily only for accounts spending enough to justify it. Say so before setting it up.

--- a/skills/adspirer-agent/SKILL.md
+++ b/skills/adspirer-agent/SKILL.md
@@ -85,10 +85,18 @@ Good candidates: a Monday performance review, a mid-month pacing check, an alert
 ceiling, a watch on a competitor's landing page, a reminder before budgets reset.
 
 
-A **local** Desktop task only fires while the app is open and the machine is awake — a laptop asleep
-at 9am simply skips the run. For anything that matters, create a **remote routine** so it runs with
-the machine off. Write the prompt so a late run behaves: "only look at today's spend; if it's past
-6pm, just summarize what changed."
+The name depends on where you're running:
+
+- **Claude Cowork** — a **scheduled task**, created with the `/schedule` skill from any chat. These
+  run remotely, on their cadence, even with the computer asleep or the app closed. Hourly, daily,
+  weekly, weekdays, or on demand. Paid plans only.
+- **Claude Code** — a **routine**. A *local* Desktop task only fires while the app is open and the
+  machine is awake, so a laptop asleep at 9am silently skips the run. Prefer a **remote routine** for
+  anything that matters; it runs on Anthropic's infrastructure with the machine off.
+
+Write the prompt so a late run behaves: "only look at today's spend; if it's past 6pm, just summarize
+what changed."
+
 
 Every scheduled run calls Adspirer tools again, drawing on the user's monthly quota exactly like a
 live conversation. Say what the cadence will cost before setting it up — weekly is the right default

--- a/skills/adspirer-agent/references/host-surfaces.md
+++ b/skills/adspirer-agent/references/host-surfaces.md
@@ -13,16 +13,24 @@ task just by asking.
 Use it for anything on a cadence: a Monday performance review, a mid-month pacing check, a watch on a
 competitor's landing page, a nudge before a budget resets.
 
-**Make it run when the user isn't there.** This is the one detail that decides whether a schedule is
-worth anything:
+### What each host calls it
 
-- **ChatGPT scheduled tasks** run whether or not the user is online, and notify by push and email.
-  Nothing to worry about.
-- **Claude Desktop local tasks** only fire while the app is open and the computer is awake. A machine
-  that sleeps through 9am skips the run; on wake, Desktop starts exactly one catch-up for the most
-  recently missed time. For anything that matters — spend, pacing, disapprovals — create a **remote
-  routine** instead, which runs on Anthropic's infrastructure with the machine off. Minimum interval
-  one hour.
+| Host | Feature | Runs when the machine is off? |
+|---|---|---|
+| ChatGPT | **Scheduled tasks** | Yes |
+| Codex | **Scheduled tasks** (automations) | Yes |
+| Claude Cowork | **Scheduled tasks**, via the `/schedule` skill | Yes — they run remotely |
+| Claude Code | **Routines** — *local* task or *remote* routine | Local: **no**. Remote: yes |
+
+**The one that bites: a Claude Code *local* Desktop task only fires while the app is open and the
+computer is awake.** A machine that sleeps through 9am skips the run; on wake, Desktop starts exactly
+one catch-up for the most recently missed time and discards anything older. For spend, pacing, or
+disapprovals, create a **remote routine** instead — Anthropic's infrastructure, machine off, minimum
+interval one hour.
+
+Cowork's scheduled tasks do *not* have this problem. They run remotely on their cadence even with the
+computer asleep or the app closed, and they can use connected tools, skills, and installed plugins —
+including this one. Available on Pro, Max, Team, and Enterprise.
 
 Write the prompt so a late run behaves. A task meant for 9am might fire at 11pm: "only look at
 today's spend; if it's past 6pm, just summarize what changed."
@@ -68,9 +76,9 @@ A styled page costs more output tokens than the same content as text. Prefer SVG
 embedded raster images, skip interactivity you don't need, and summarize large datasets rather than
 inlining every row.
 
-## Claude — scheduled tasks and routines
+## Claude Code — routines
 
-Claude Desktop's **Routines** page holds two kinds:
+Claude Code Desktop's **Routines** page holds two kinds:
 
 - **Local scheduled tasks** run on the user's machine. They only fire while the desktop app is open
   and the computer is awake; a machine that sleeps through 9am simply skips the run, and on wake
@@ -83,6 +91,37 @@ Monday at 9am" — so offer to set it up rather than describing the UI.
 
 **A local task can silently skip a day.** For anything that matters — budget pacing, spend spikes,
 disapproved ads — create a **remote routine** so it runs with the machine off.
+
+`/loop` is a third option, but it lives only inside the current session and dies with it. Fine for
+polling something for the next ten minutes; useless for a Monday report.
+
+## Claude Cowork — scheduled tasks
+
+Created with the `/schedule` skill from any chat, or from **Scheduled** in the sidebar. Cadences:
+hourly, daily, weekly, weekdays, or on demand.
+
+They **run remotely**, on their cadence, even when the computer is asleep or the Claude Desktop app is
+closed — so unlike a Claude Code local task, there's no reliability caveat. They have the same
+capabilities as a normal Cowork task, including connected tools, skills, and installed plugins.
+
+Available on Pro, Max, Team, and Enterprise.
+
+## Codex — scheduled tasks (automations)
+
+The user creates one by asking inside a Codex task — describing the work, the cadence, and whether
+each run continues the existing task or starts fresh — or from the **Scheduled** view.
+
+That view is also the **inbox**: each run's findings land there with an unread indicator, and a run
+with nothing to report can archive itself. Cadence can be a minute-based interval for a tight
+follow-up loop, a daily or weekly time, or a custom RRULE.
+
+Runs are unattended and inherit the sandbox settings already in force, so they execute without
+approval prompts where policy allows. Be conservative about what you schedule: an unattended run that
+writes to an ad account spends real money without anyone watching.
+
+**Codex hooks are not a scheduler.** They are event handlers — `SessionStart`, `PreToolUse`,
+`PostToolUse`, `Stop` — configured by the user for their own environment. Never offer a hook as a way
+to run a recurring report.
 
 ## ChatGPT — sites
 

--- a/skills/adspirer-creative/SKILL.md
+++ b/skills/adspirer-creative/SKILL.md
@@ -98,4 +98,5 @@ Creative fatigue is a recurring problem, not a one-time fix. Rather than promisi
 offer to schedule a fatigue check on this host — frequency and CTR, every couple of weeks — so the
 next refresh is prompted by the data instead of by someone remembering.
 
-A **remote routine** beats a local Desktop task here; fatigue doesn't wait for the laptop to be open.
+A Cowork **scheduled task**, or a **remote routine** in Claude Code — not a local Desktop task.
+Fatigue doesn't wait for the laptop to be open.

--- a/skills/adspirer-launch/SKILL.md
+++ b/skills/adspirer-launch/SKILL.md
@@ -84,8 +84,8 @@ first week is when it either finds its footing or quietly burns budget, and the 
 the second before the invoice does. Set it on the metric that defines success: CPA ceiling, ROAS
 floor, daily spend.
 
-Make it a **remote routine** rather than a local Desktop task, so a sleeping laptop doesn't skip the
-day the campaign went wrong.
+A Cowork **scheduled task** runs remotely; in Claude Code make it a **remote routine** rather than a
+local Desktop task, so a sleeping laptop doesn't skip the day the campaign went wrong.
 
 Each run costs tool calls, so match the cadence to the spend.
 

--- a/skills/adspirer-optimize/SKILL.md
+++ b/skills/adspirer-optimize/SKILL.md
@@ -92,8 +92,10 @@ Offer to schedule the check on this host. They can create one just by asking, an
 notification wherever they already are.
 
 
-Use a **remote routine**, not a local Desktop task. A local task is skipped whenever the machine is
-asleep — and the overspend you're watching for does not wait for the laptop to open.
+In Cowork, a **scheduled task** (`/schedule`) — it runs remotely. In Claude Code, a **remote
+routine**, not a local Desktop task: a local one is skipped whenever the machine is asleep, and the
+overspend you're watching for does not wait for the laptop to open.
+
 
 Each run costs tool calls against their quota. Mid-month and month-end beats daily for pacing; daily
 is for accounts where a day of overspend is real money.

--- a/skills/adspirer-performance-review/SKILL.md
+++ b/skills/adspirer-performance-review/SKILL.md
@@ -87,8 +87,11 @@ A review is worth more every week than once. When the user likes what they just 
 schedule it — this host can, and they can create it just by asking.
 
 
-Prefer a **remote routine** over a local Desktop task — a local one is skipped whenever the machine
-is asleep at the scheduled hour, which is exactly when a Monday-morning review would fire.
+In Cowork, that's a **scheduled task** via `/schedule` — it runs remotely, so a sleeping laptop
+doesn't matter. In Claude Code, it's a **routine**; prefer a *remote* one, because a local Desktop
+task is skipped whenever the machine is asleep at the scheduled hour — exactly when a Monday-morning
+review would fire.
+
 
 Each run costs tool calls against their monthly quota, the same as a live conversation. Weekly is the
 right default; daily only for accounts spending enough to justify it. Say so before setting it up.


### PR DESCRIPTION
## What each host actually calls it

| Host | Feature | Runs with the machine off? |
|---|---|---|
| ChatGPT | Scheduled tasks | Yes |
| Codex | Scheduled tasks (automations) | Yes |
| Claude Cowork | Scheduled tasks, via `/schedule` | **Yes — they run remotely** |
| Claude Code | Routines — *local* task or *remote* routine | Local: **no**. Remote: yes |

## Corrections

**I had a factual error in the merged skills.** I wrote that a Claude scheduled task is skipped when
the machine sleeps. That is false for **Cowork** — its scheduled tasks run remotely, on cadence, even
with the computer asleep or the app closed. The caveat applies only to a Claude Code **local** Desktop
task, where a remote routine is the fix. Source:
[support.claude.com](https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork).

**Cowork and Claude Code were treated as one product.** They aren't: `/schedule` → scheduled task in
Cowork; Routines page → local task or remote routine in Claude Code.

## Codex, added

It had no scheduling guidance at all. Codex **scheduled tasks** (automations) support minute
intervals, daily/weekly times, or a custom RRULE. Findings land in the **Scheduled** inbox with an
unread marker, and a run with nothing to report archives itself — which suits a weekly review that's
usually uneventful.

Runs are **unattended**, inheriting the sandbox already in force. So the skills tell the agent to keep
scheduled ad work read-only: an unattended run that changes budgets spends real money with nobody
watching.

**Hooks are not a scheduler.** They're event handlers — `SessionStart`, `PreToolUse`, `PostToolUse`,
`Stop` — and belong to the user's own config. The skills say never to offer one for a recurring
report, and a lint enforces it.

## The lint caught me

The hooks check first failed on my own sentence *forbidding* hooks. It now ignores negations, and I
verified it still fails on `Use a hook to schedule the weekly report` rather than passing vacuously —
the same trap as the `**Site**` lint in #17.

`./scripts/validate.sh` → **114/114**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LiDsW9XF3Y6k17a6mCFSv