### PR TITLE
fix(commands): quote argument-hint in wasted-spend frontmatter

### DIFF
--- a/commands/wasted-spend.md
+++ b/commands/wasted-spend.md
@@ -1,6 +1,6 @@
 ---
 description: Find and fix wasted ad spend across all platforms
-argument-hint: <optional: specific platform>
+argument-hint: "<optional: specific platform>"
 ---
 Run a wasted spend analysis across $ARGUMENTS (default: all connected platforms).
 


### PR DESCRIPTION
## What

One-line fix: quote the `argument-hint` value in `commands/wasted-spend.md` frontmatter.

## Why

`argument-hint: <optional: specific platform>` is invalid YAML — the unquoted `: ` after `optional` parses as a nested mapping and fails. This is the exact error in the community-marketplace nightly bump logs (anthropics/claude-plugins-community#964):

```
adspirer-ads-agent: skipped (validation failed ... ❯ frontmatter: YAML frontmatter failed to parse)
```

It also means the command loads with empty metadata at runtime (description and argument hint silently dropped).

Verified: all 101 frontmatter blocks in the repo now parse; `claude plugin validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7qYQgPCva43HGu6K3kgiF