### PR TITLE
feat(skills): adspirer-get-started — agent-native onboarding skill

### DIFF
--- a/docs/get-started-skill.md
+++ b/docs/get-started-skill.md
@@ -1,0 +1,80 @@
+# The Adspirer get-started skill — agent-native signup
+
+Website copy + rationale for distributing Adspirer onboarding as an
+installable agent skill, modeled on here.now's distribution pattern
+(`npx skills add heredotnow/skill --skill here-now -g`).
+
+## What it is
+
+`skills/adspirer-get-started/SKILL.md` is a small, self-contained skill whose
+only job is onboarding: detect which AI client the agent is running in,
+install the right Adspirer artifact (Claude Code plugin, Claude/ChatGPT
+connector, Cursor/Codex MCP config, Gemini extension), walk the user through
+the OAuth signup (sign in with Google/email → account created → connect ad
+platforms → plan), and verify with `get_connections_status` before handing
+off to `start_here` or `/adspirer:setup`.
+
+The classic web signup flow (read → email → web app → onboarding → connect
+ads → pick plan) stays as-is. This is a parallel, agent-native funnel: the
+user starts inside the AI client they already use, and the OAuth redirect IS
+the signup.
+
+## Website section (drop-in copy)
+
+---
+
+### Add Adspirer to your AI agent
+
+Have your agent set Adspirer up for you — installation, account, ad platform
+connections, first campaign review.
+
+**If you have npm** (installs for Claude Code, Cursor, Codex, and more):
+
+```bash
+npx skills add amekala/ads-mcp --skill adspirer-get-started -g
+```
+
+**If not** (Claude Code / Claude Cowork):
+
+```bash
+curl -fsSL https://www.adspirer.com/install.sh | bash
+```
+
+**No terminal at all?** Paste this into Claude, ChatGPT, or any assistant
+that can read the web:
+
+> Fetch https://raw.githubusercontent.com/amekala/ads-mcp/main/skills/adspirer-get-started/SKILL.md
+> and follow it to set up Adspirer for me.
+
+Then say **"set up adspirer"** — your agent takes it from there. New
+campaigns are always created paused; nothing spends without your say-so.
+
+---
+
+## Hosting checklist (to go live)
+
+1. Serve `scripts/install-skill.sh` at `https://www.adspirer.com/install.sh`
+   (redirect or copy; the script itself downloads the skill from raw
+   GitHub `main`, so it always installs the latest version).
+2. Add the section above to the website (docs page and/or landing page).
+3. Optional: register the skill on skills.sh (the `npx skills` registry
+   indexes public GitHub repos with `skills/` directories automatically —
+   verify `amekala/ads-mcp` appears and the exact add command works).
+
+## How each path works
+
+| Path | Mechanism | Reaches |
+|---|---|---|
+| `npx skills add amekala/ads-mcp --skill adspirer-get-started -g` | Vercel `skills` CLI reads this repo's `skills/` dir, installs to every detected agent's global skills location | Claude Code, Cursor, Codex, other CLI agents |
+| `curl … install.sh \| bash` | Downloads SKILL.md into `~/.claude/skills/adspirer-get-started/` (auto-discovered, no install step) | Claude Code, Claude Cowork |
+| Paste-a-prompt | Agent fetches the SKILL.md from raw GitHub and follows it as instructions | claude.ai, ChatGPT web/desktop — anything with web fetch |
+| Plugin (existing) | The same skill ships inside the plugin, so plugin users get onboarding help for teammates/other machines | Claude Code / Cowork plugin installs |
+
+## Maintenance
+
+- The skill carries a `Skill version:` line — bump it when content changes.
+- It deliberately defers volatile facts (pricing, quotas, per-client quirks)
+  to https://www.adspirer.com/docs and CONNECTING.md, so it goes stale
+  slowly. Keep those pages current instead.
+- CI validates its frontmatter like every other skill
+  (`scripts/validate-frontmatter.mjs`).

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Adspirer get-started skill installer.
+#
+# Intended to be served at https://www.adspirer.com/install.sh so users can run:
+#   curl -fsSL https://www.adspirer.com/install.sh | bash
+# Also works directly from the repo:
+#   curl -fsSL https://raw.githubusercontent.com/amekala/ads-mcp/main/scripts/install-skill.sh | bash
+#
+# Installs the skill into ~/.claude/skills/adspirer-get-started/ where Claude
+# Code and Claude Cowork auto-discover it. Users with npm can instead run:
+#   npx skills add amekala/ads-mcp --skill adspirer-get-started -g
+# which also installs for other agents (Cursor, Codex, ...).
+set -euo pipefail
+
+SKILL_NAME="adspirer-get-started"
+SKILL_DIR="${HOME}/.claude/skills/${SKILL_NAME}"
+REPO_BASE="https://raw.githubusercontent.com/amekala/ads-mcp/main/skills/${SKILL_NAME}"
+
+die() {
+  echo "error: $1" >&2
+  exit 1
+}
+
+command -v curl >/dev/null 2>&1 || die "requires curl"
+command -v mktemp >/dev/null 2>&1 || die "requires mktemp"
+
+atomic_download() {
+  local url="$1" destination="$2" tmp
+  tmp="$(mktemp "${destination}.tmp.XXXXXX")"
+  curl -fsSL "$url" -o "$tmp" || { rm -f "$tmp"; die "download failed: $url"; }
+  mv "$tmp" "$destination"
+}
+
+echo "Installing the Adspirer get-started skill..."
+
+mkdir -p "$SKILL_DIR"
+atomic_download "${REPO_BASE}/SKILL.md" "${SKILL_DIR}/SKILL.md"
+
+echo ""
+echo "done — installed to ${SKILL_DIR}"
+echo ""
+echo "Next: restart Claude Code (or Cowork), then say:"
+echo "  \"set up adspirer\""
+echo ""
+echo "The skill walks your agent through installing the full Adspirer"
+echo "plugin/connector for your environment, creating your account, and"
+echo "connecting your ad platforms."

--- a/skills/adspirer-get-started/SKILL.md
+++ b/skills/adspirer-get-started/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: adspirer-get-started
+description: >
+  Install and set up Adspirer — the AI advertising agent for Google Ads,
+  Meta Ads (Facebook & Instagram), TikTok Ads, LinkedIn Ads, Amazon Ads, and
+  ChatGPT Ads. Use when asked to "install adspirer", "set up adspirer",
+  "get adspirer", "connect my ad accounts", "manage my ads from here",
+  "add the adspirer plugin/connector", "sign up for adspirer", or when the
+  user wants to run ad campaigns from an AI assistant but Adspirer is not
+  connected yet. Walks through the right install path for this environment
+  (Claude Code, Claude/Cowork, ChatGPT, Cursor, Codex, Gemini CLI), the
+  OAuth sign-up flow, and connecting ad accounts — then verifies it works.
+---
+
+# Get started with Adspirer
+
+**Skill version: 1.0.0**
+
+Adspirer connects AI assistants to the user's real ad accounts — 400+ tools
+across Google Ads, Meta Ads, TikTok Ads, LinkedIn Ads, Amazon Ads, and
+ChatGPT Ads — through one remote MCP server:
+
+```
+https://mcp.adspirer.com/mcp
+```
+
+Your job with this skill: get the user from "nothing installed" to a working,
+authenticated Adspirer connection with at least one ad platform linked, then
+hand off to their first real task.
+
+To install or update this skill: `npx skills add amekala/ads-mcp --skill adspirer-get-started -g`
+(or `curl -fsSL https://www.adspirer.com/install.sh | bash`).
+
+## Current docs
+
+Instructions drift. For anything not covered here — pricing, plans, quotas,
+troubleshooting, a client not listed below — read the live docs before
+answering, and trust them over this file:
+
+- https://www.adspirer.com/docs
+- https://raw.githubusercontent.com/amekala/ads-mcp/main/CONNECTING.md
+
+## Step 1 — Detect the environment
+
+Pick the install path for where you are running right now:
+
+| Signal | Environment |
+|---|---|
+| You can run shell commands and `CLAUDECODE=1` is set | **Claude Code** |
+| You are Claude with connectors/apps but no local shell | **Claude web/desktop or Cowork** |
+| You are ChatGPT | **ChatGPT** |
+| Cursor (rules, `~/.cursor/`) | **Cursor** |
+| Codex (`~/.codex/config.toml`) | **Codex** |
+| Gemini CLI | **Gemini CLI** |
+
+If you cannot tell, ask the user which app they are using.
+
+Before installing anything, check whether Adspirer is already connected: if an
+`adspirer` MCP server or its tools (`get_connections_status`, `google_ads`,
+`start_here`) are available, skip to Step 3.
+
+## Step 2 — Install (per environment)
+
+### Claude Code — full plugin (recommended)
+
+```
+/plugin marketplace add amekala/ads-mcp
+/plugin install adspirer-advertising-agent
+```
+
+Then run `/mcp`, find the **adspirer** server, and click to authenticate.
+Do NOT also run `claude mcp add` for adspirer — that creates a duplicate
+registration and connection errors. To check: `claude mcp list` should show
+exactly one adspirer entry.
+
+MCP-only alternative (raw tools, no agent/skills/commands):
+`claude mcp add --transport http adspirer https://mcp.adspirer.com/mcp`
+
+### Claude web/desktop and Claude Cowork
+
+1. Directory (if listed for the user's plan): have them search "Adspirer" in
+   **Settings → Connectors → Browse connectors** and click **Connect**.
+2. Otherwise add a custom connector: **Settings → Connectors → Add custom
+   connector** → Name `Adspirer`, URL `https://mcp.adspirer.com/mcp`,
+   Authentication **OAuth**.
+3. On Team/Enterprise plans only an Owner can add org connectors
+   (**Customize → Connectors → Organization connectors → Add custom
+   connector**); members then connect individually in their own settings.
+
+### ChatGPT (desktop, web, or work)
+
+Requires Plus/Pro (or a workspace admin on Business/Enterprise):
+**Settings → Connectors → Add custom connector** → Name `Adspirer`, URL
+`https://mcp.adspirer.com/mcp`, Authentication **OAuth 2.1**.
+
+### Cursor
+
+Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
+
+```json
+{"mcpServers": {"adspirer": {"url": "https://mcp.adspirer.com/mcp"}}}
+```
+
+Then restart Cursor and approve the OAuth prompt on first tool use.
+
+### Codex
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.adspirer]
+url = "https://mcp.adspirer.com/mcp"
+```
+
+### Gemini CLI
+
+```bash
+gemini extensions install github.com/amekala/ads-mcp
+```
+
+Re-auth later with `/mcp auth adspirer` if tokens expire.
+
+## Step 3 — Sign up / sign in (OAuth)
+
+The first connection (or first tool call) opens Adspirer's OAuth page in the
+browser. Tell the user what to expect — this IS the signup flow:
+
+1. **Sign in with Google or email.** No pre-existing account needed — this
+   creates their free Adspirer account.
+2. **Authorize** the AI client to access their Adspirer account.
+3. **Connect ad accounts** at https://adspirer.ai/connections — Google Ads,
+   Meta, TikTok, LinkedIn, Amazon, ChatGPT Ads; any combination works, and
+   they can add more later.
+4. **Plan:** there is a free trial; paid plans are listed at
+   https://www.adspirer.com/pricing. Don't quote prices from memory — read
+   the pricing page if asked.
+
+The browser redirects back to the AI client automatically when done.
+
+## Step 4 — Verify, then hand off
+
+1. Call `get_connections_status`. Success + at least one platform connected
+   means setup is done. (In Claude Code the tools may be behind platform
+   routers — `google_ads`, `meta_ads`, etc. — with `action: "list_tools"` /
+   `"execute"`.)
+2. If the server responds but no platforms are connected, send the user to
+   https://adspirer.ai/connections and re-check.
+3. Then start the first real task:
+   - Call `start_here` for a personalized guide based on their real account
+     state, or
+   - In Claude Code, run `/adspirer:setup` to bootstrap a brand workspace
+     from their local docs and live campaign data.
+
+## Safety facts to tell the user
+
+- New campaigns are always created **PAUSED** — nothing spends until they
+  explicitly launch it.
+- Read tools (performance, research) are safe to allow always; write tools
+  (budgets, campaign changes) should stay on per-call confirmation.
+- Ad spend is billed by the ad platforms to the user's own accounts;
+  Adspirer's subscription is separate.
+
+## Troubleshooting (quick hits)
+
+- **Nothing works at all:** disconnect and reconnect the connector, complete
+  OAuth again. Web clients (Claude/ChatGPT) drop connectors every week or
+  two; this is normal.
+- **Claude Code duplicate server:** `claude mcp remove adspirer` if the
+  plugin is installed (or keep only the manual entry, not both).
+- **One platform fails, others work:** reconnect that platform at
+  https://adspirer.ai/connections.
+- **Session expired:** log out and back in at https://adspirer.ai, retry.
+- Anything else: https://www.adspirer.com/docs, or support@adspirer.com.


### PR DESCRIPTION
Adds a standalone onboarding skill (here.now-style distribution): host detection → per-client install → OAuth signup → ad-account connection → verification → handoff. Ships with a curl installer (`scripts/install-skill.sh`, to be served at adspirer.com/install.sh) and website copy (`docs/get-started-skill.md`) covering the npx / curl / paste-a-prompt paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7qYQgPCva43HGu6K3kgiF