### PR TITLE
feat(get-started): one-command onboarding — auto-launch setup, action-first chat flows

### DIFF
--- a/docs/get-started-skill.md
+++ b/docs/get-started-skill.md
@@ -30,36 +30,37 @@ the signup.
 
 ---
 
-### Add Adspirer to your AI agent
+### Add Adspirer to your AI
 
-Have your agent set Adspirer up for you — installation, account, ad platform
-connections, first campaign review.
+One command (or one tap) — your agent handles the rest: installation,
+account sign-in, connecting your ad platforms.
 
-**If you have npm** (installs for Claude Code, Cursor, Codex, and more):
+**Using the ChatGPT or Claude app?** Install with one tap:
 
-```bash
-npx skills add amekala/ads-mcp --skill adspirer-get-started -g
-```
+- ChatGPT: [Adspirer on the ChatGPT App Store](https://chatgpt.com/apps/adspirer/asdk_app_69461dc91ee48191ae4a14eb9bde1c21)
+- Claude: [Adspirer in the Claude plugin directory](https://claude.ai/directory/plugins/adspirer-ads-agent%40knowledge-work-plugins)
 
-**If not** (Claude Code / Claude Cowork):
+Or paste this into the chat — setup starts immediately:
+
+> Fetch https://raw.githubusercontent.com/amekala/ads-mcp/main/skills/adspirer-get-started/SKILL.md
+> and follow it to set up Adspirer for me.
+
+**In a terminal?** One command installs the skill and drops you straight
+into setup (launches Claude Code automatically when it's installed):
 
 ```bash
 curl -fsSL https://www.adspirer.com/install.sh | bash
 ```
 
-**No terminal at all?** Paste this into Claude, ChatGPT, or any assistant
-that can read the web:
+With npm instead (installs the skill for Claude Code, Cursor, Codex, and
+more, then starts setup):
 
-> Fetch https://raw.githubusercontent.com/amekala/ads-mcp/main/skills/adspirer-get-started/SKILL.md
-> and follow it to set up Adspirer for me.
+```bash
+npx skills add amekala/ads-mcp --skill adspirer-get-started -g && claude "set up adspirer"
+```
 
-Then say **"set up adspirer"** — your agent takes it from there. New
-campaigns are always created paused; nothing spends without your say-so.
-
-**Or install straight from your app's directory** — no skill needed:
-
-- ChatGPT: [Adspirer on the ChatGPT App Store](https://chatgpt.com/apps/adspirer/asdk_app_69461dc91ee48191ae4a14eb9bde1c21)
-- Claude: [Adspirer in the Claude plugin directory](https://claude.ai/directory/plugins/adspirer-ads-agent%40knowledge-work-plugins)
+New campaigns are always created paused; nothing spends without your
+say-so.
 
 ---
 

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -39,9 +39,16 @@ atomic_download "${REPO_BASE}/SKILL.md" "${SKILL_DIR}/SKILL.md"
 echo ""
 echo "done — installed to ${SKILL_DIR}"
 echo ""
-echo "Next: restart Claude Code (or Cowork), then say:"
-echo "  \"set up adspirer\""
-echo ""
-echo "The skill walks your agent through installing the full Adspirer"
-echo "plugin/connector for your environment, creating your account, and"
+
+# Hand off straight into setup: if Claude Code is installed and we can attach
+# a terminal, launch it with the setup prompt so the skill takes over
+# immediately. Set ADSPIRER_NO_LAUNCH=1 to install the skill only.
+if [[ -z "${ADSPIRER_NO_LAUNCH:-}" ]] && command -v claude >/dev/null 2>&1 && [[ -t 1 && -r /dev/tty ]]; then
+  echo "Launching Claude Code to finish setup..."
+  echo ""
+  exec claude "Set up Adspirer for me — use the adspirer-get-started skill." </dev/tty
+fi
+
+echo "Next: open Claude Code (or Cowork) and say: \"set up adspirer\""
+echo "Your agent handles the rest — plugin install, account sign-in, and"
 echo "connecting your ad platforms."

--- a/skills/adspirer-get-started/SKILL.md
+++ b/skills/adspirer-get-started/SKILL.md
@@ -14,7 +14,13 @@ description: >
 
 # Get started with Adspirer
 
-**Skill version: 1.1.0**
+**Skill version: 1.2.0**
+
+**Act immediately.** When this skill loads — whether installed, fetched from
+a URL, or pasted into the chat — start the flow now: detect the environment,
+present the single next action, and guide the user through it. Do not
+summarize these instructions, list the options, or ask what they'd like to
+do first.
 
 Adspirer connects AI assistants to the user's real ad accounts — 400+ tools
 across Google Ads, Meta Ads, TikTok Ads, LinkedIn Ads, Amazon Ads, and
@@ -91,35 +97,36 @@ MCP-only alternative (raw tools, no agent/skills/commands):
 
 ### Claude web/desktop and Claude Cowork (chat app)
 
-Adspirer is in the Claude plugin directory. In order of preference:
+Adspirer is in the Claude plugin directory. Don't explain the options — give
+the user this one action:
 
-1. **Directory listing (send this link):**
-   https://claude.ai/directory/plugins/adspirer-ads-agent%40knowledge-work-plugins
-   — the user clicks **Install**, then connects and completes OAuth when
-   prompted. They can also reach it in-app: **Browse plugins / Directory →
-   search "Adspirer"**.
-2. **Connector directory:** **Settings → Connectors → Browse connectors** →
-   search "Adspirer" → **Connect** (if listed for their plan).
-3. **Fallback — custom connector:** **Settings → Connectors → Add custom
-   connector** → Name `Adspirer`, URL `https://mcp.adspirer.com/mcp`,
-   Authentication **OAuth**.
-4. On Team/Enterprise plans only an Owner can add org connectors
-   (**Customize → Connectors → Organization connectors → Add custom
-   connector**); members then connect individually in their own settings.
+> Install Adspirer from the Claude directory:
+> https://claude.ai/directory/plugins/adspirer-ads-agent%40knowledge-work-plugins
+> Click **Install**, sign in with Google or email when the Adspirer window
+> opens, and tell me when you're done.
+
+If you can open links for the user, open that listing directly. Then go to
+Step 4 (verify). Fallbacks only if the listing doesn't work for them:
+**Settings → Connectors → Browse connectors → "Adspirer" → Connect**, or
+**Add custom connector** (Name `Adspirer`, URL `https://mcp.adspirer.com/mcp`,
+OAuth). On Team/Enterprise, org connectors are added by an Owner under
+**Customize → Connectors → Organization connectors**.
 
 ### ChatGPT (chat app — desktop, web, mobile, or work)
 
-Adspirer is a published ChatGPT App. In order of preference:
+Adspirer is a published ChatGPT App. Don't explain the options — give the
+user this one action:
 
-1. **App listing (send this link):**
-   https://chatgpt.com/apps/adspirer/asdk_app_69461dc91ee48191ae4a14eb9bde1c21
-   — the user clicks **Install / Connect** and completes the OAuth sign-in.
-   They can also find it in-app: **Settings → Apps → search "Adspirer"**, or
-   just by asking ChatGPT to use the Adspirer app.
-2. **Fallback — custom connector** (Plus/Pro, or a workspace admin on
-   Business/Enterprise, and only if apps are restricted): **Settings →
-   Connectors → Add custom connector** → Name `Adspirer`, URL
-   `https://mcp.adspirer.com/mcp`, Authentication **OAuth 2.1**.
+> Install the Adspirer app:
+> https://chatgpt.com/apps/adspirer/asdk_app_69461dc91ee48191ae4a14eb9bde1c21
+> Tap **Install / Connect**, sign in with Google or email, and tell me when
+> you're done.
+
+If you can open links for the user, open that listing directly. (In-app
+alternative: **Settings → Apps → search "Adspirer"**.) Then go to Step 4
+(verify). Fallback only if apps are restricted in their workspace:
+**Settings → Connectors → Add custom connector** (Name `Adspirer`, URL
+`https://mcp.adspirer.com/mcp`, OAuth 2.1).
 
 ### Cursor
 


### PR DESCRIPTION
The install command is now the entire onboarding: the curl installer launches Claude Code with the setup prompt automatically (TTY + claude CLI present; `ADSPIRER_NO_LAUNCH=1` opts out), the skill starts acting the moment it loads instead of summarizing options, and chat-app users get exactly one action — the official ChatGPT App Store / Claude directory listing — with sign-in guidance and verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7qYQgPCva43HGu6K3kgiF