### PR TITLE
fix(plugin): packaging fixes — agent tool access, no global takeover, valid .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,8 @@
 {
-  "adspirer": {
-    "type": "http",
-    "url": "https://mcp.adspirer.com/mcp"
+  "mcpServers": {
+    "adspirer": {
+      "type": "http",
+      "url": "https://mcp.adspirer.com/mcp"
+    }
   }
 }

--- a/CONNECTING.md
+++ b/CONNECTING.md
@@ -98,7 +98,7 @@ All tools include safety annotations (`readOnlyHint`, `destructiveHint`) so Clau
 1. Open Claude Code in your brand/project folder
 2. Run `/plugin marketplace add amekala/ads-mcp`
 3. Run `/plugin install adspirer-advertising-agent`
-4. Run `/mcp` — find **plugin:adspirer:adspirer** and click to authenticate via OAuth
+4. Run `/mcp` — find the **adspirer** server (e.g. **plugin:adspirer-advertising-agent:adspirer**) and click to authenticate via OAuth
 5. Run `/adspirer:setup` — the agent will pull your campaign data and create a brand workspace (CLAUDE.md)
 
 Available commands after setup:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Install the full Adspirer plugin (agent + skills + commands + MCP server):
 1. Open Claude Code
 2. Run `/plugin marketplace add amekala/ads-mcp`
 3. Run `/plugin install adspirer-advertising-agent`
-4. Run `/mcp` — find **plugin:adspirer:adspirer** and click to authenticate
+4. Run `/mcp` — find the **adspirer** server (e.g. **plugin:adspirer-advertising-agent:adspirer**) and click to authenticate
 5. Run `/adspirer:setup` to pull your campaign data and create your brand workspace
 
 This gives you a brand-aware performance marketing agent with persistent memory, competitive research via web search, campaign creation with ad extensions, and slash commands for common workflows.

--- a/agents/performance-marketing-agent.md
+++ b/agents/performance-marketing-agent.md
@@ -5,8 +5,10 @@ description: |
   ad platform data, bootstraps brand workspaces, and manages campaigns across
   Google Ads, Meta Ads, Amazon Ads, ChatGPT Ads, LinkedIn Ads, and TikTok Ads
   with brand awareness and persistent memory.
-tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch, WebSearch, Task
-model: sonnet
+# tools deliberately not restricted — this agent needs the Adspirer MCP tools, and a
+# `tools:` allowlist would exclude every MCP tool (plugin install method changes the
+# prefix, so no allowlist entry can name them reliably). Omitted = inherit everything.
+maxTurns: 25
 memory: project
 skills:
   - adspirer-agent
@@ -64,8 +66,8 @@ Try calling `get_connections_status`.
 **If the MCP server is not found** (server "adspirer" not available): the Adspirer MCP server hasn't been registered yet. Tell the user:
 
 "The Adspirer MCP server isn't connected yet. Please run these steps:
-1. Run `/mcp` and find **plugin:adspirer:adspirer** -- click to authenticate
-2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer`
+1. Run `/mcp` and find the **adspirer** server (listed under the plugin, e.g. **plugin:adspirer-advertising-agent:adspirer**) -- click to authenticate
+2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer-advertising-agent`
 3. After authenticating, run `/adspirer:setup` again"
 
 As a fallback, you can also register the MCP server directly:

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -7,7 +7,7 @@ Run the full brand workspace setup. Follow these steps in order:
 
 1. **Connect to Adspirer** — Call `get_connections_status`.
    - If it works: continue to step 2.
-   - If the MCP server is not found: tell the user "Run `/mcp` and find **plugin:adspirer:adspirer** — click to authenticate. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer`. After authenticating, run `/adspirer:setup` again."
+   - If the MCP server is not found: tell the user "Run `/mcp` and find the **adspirer** server (listed under the plugin, e.g. **plugin:adspirer-advertising-agent:adspirer**) — click to authenticate. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer-advertising-agent`. After authenticating, run `/adspirer:setup` again."
    - As a fallback: run `claude mcp add --transport http adspirer https://mcp.adspirer.com/mcp` via Bash, then tell the user to restart Claude Code, run `/mcp` to authenticate, then run `/adspirer:setup` again.
    - If the MCP server is registered but not authenticated: tell the user "Run `/mcp`, find the Adspirer server, and authenticate it. Then run `/adspirer:setup` again."
 2. **Scan local folder** for brand docs — use Glob to find files: `**/*.md`, `**/*.txt`, `**/*.csv`, `**/*.yaml`, `**/*.json`, `**/*.pdf`. Read any files found.

--- a/cookbook/master-notebook.md
+++ b/cookbook/master-notebook.md
@@ -40,7 +40,7 @@ The pattern: **strategy stays human, execution becomes instant.**
 |--------|-------|
 | **ChatGPT** | Settings → Connectors → Add Connector → URL: `https://mcp.adspirer.com/mcp` |
 | **Claude** | Settings → Connectors → Add Custom Connector → URL: `https://mcp.adspirer.com/mcp` |
-| **Claude Code** | `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer` |
+| **Claude Code** | `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer-advertising-agent` |
 | **Gemini CLI** | `gemini extensions install github.com/amekala/ads-mcp` |
 | **Cursor** | Add `"adspirer": {"url": "https://mcp.adspirer.com/mcp"}` to `mcp.json` |
 

--- a/plugins/adspirer/agents/performance-marketing-agent.toml
+++ b/plugins/adspirer/agents/performance-marketing-agent.toml
@@ -45,8 +45,8 @@ Try calling `get_connections_status`.
 **If the MCP server is not found** (server "adspirer" not available): the Adspirer MCP server hasn't been registered yet. Tell the user:
 
 "The Adspirer MCP server isn't connected yet. Please run these steps:
-1. Run `/mcp` and find **plugin:adspirer:adspirer** -- click to authenticate
-2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer`
+1. Run `/mcp` and find the **adspirer** server (listed under the plugin, e.g. **plugin:adspirer-advertising-agent:adspirer**) -- click to authenticate
+2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer-advertising-agent`
 3. After authenticating, run `/adspirer:setup` again"
 
 As a fallback, you can also register the MCP server directly:

--- a/plugins/codex/adspirer/agents/performance-marketing-agent.toml
+++ b/plugins/codex/adspirer/agents/performance-marketing-agent.toml
@@ -45,8 +45,8 @@ Try calling `get_connections_status`.
 **If the MCP server is not found** (server "adspirer" not available): the Adspirer MCP server hasn't been registered yet. Tell the user:
 
 "The Adspirer MCP server isn't connected yet. Please run these steps:
-1. Run `/mcp` and find **plugin:adspirer:adspirer** -- click to authenticate
-2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer`
+1. Run `/mcp` and find the **adspirer** server (listed under the plugin, e.g. **plugin:adspirer-advertising-agent:adspirer**) -- click to authenticate
+2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer-advertising-agent`
 3. After authenticating, run `/adspirer:setup` again"
 
 As a fallback, you can also register the MCP server directly:

--- a/plugins/cursor/adspirer/.cursor/agents/performance-marketing-agent.md
+++ b/plugins/cursor/adspirer/.cursor/agents/performance-marketing-agent.md
@@ -48,8 +48,8 @@ Try calling `get_connections_status`.
 **If the MCP server is not found** (server "adspirer" not available): the Adspirer MCP server hasn't been registered yet. Tell the user:
 
 "The Adspirer MCP server isn't connected yet. Please run these steps:
-1. Run `/mcp` and find **plugin:adspirer:adspirer** -- click to authenticate
-2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer`
+1. Run `/mcp` and find the **adspirer** server (listed under the plugin, e.g. **plugin:adspirer-advertising-agent:adspirer**) -- click to authenticate
+2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer-advertising-agent`
 3. After authenticating, run `/adspirer:setup` again"
 
 As a fallback, you can also register the MCP server directly:

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -186,8 +186,10 @@ description: |
   ad platform data, bootstraps brand workspaces, and manages campaigns across
   Google Ads, Meta Ads, Amazon Ads, ChatGPT Ads, LinkedIn Ads, and TikTok Ads
   with brand awareness and persistent memory.
-tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch, WebSearch, Task
-model: sonnet
+# tools deliberately not restricted — this agent needs the Adspirer MCP tools, and a
+# `tools:` allowlist would exclude every MCP tool (plugin install method changes the
+# prefix, so no allowlist entry can name them reliably). Omitted = inherit everything.
+maxTurns: 25
 memory: project
 skills:
   - adspirer-agent

--- a/settings.json
+++ b/settings.json
@@ -1,3 +1,0 @@
-{
-  "agent": "performance-marketing-agent"
-}

--- a/shared/agents/performance-marketing-agent/PROMPT.md
+++ b/shared/agents/performance-marketing-agent/PROMPT.md
@@ -37,8 +37,8 @@ Try calling `get_connections_status`.
 **If the MCP server is not found** (server "adspirer" not available): the Adspirer MCP server hasn't been registered yet. Tell the user:
 
 "The Adspirer MCP server isn't connected yet. Please run these steps:
-1. Run `/mcp` and find **plugin:adspirer:adspirer** -- click to authenticate
-2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer`
+1. Run `/mcp` and find the **adspirer** server (listed under the plugin, e.g. **plugin:adspirer-advertising-agent:adspirer**) -- click to authenticate
+2. If you don't see it, run `/plugin marketplace add amekala/ads-mcp` then `/plugin install adspirer-advertising-agent`
 3. After authenticating, run `/adspirer:setup` again"
 
 As a fallback, you can also register the MCP server directly:


### PR DESCRIPTION
Fixes the five packaging issues from the 2026-08-04 user report (Bo Laanen) that made the Claude Code plugin unusable as installed. No server-side changes — the MCP hub is untouched.

## Changes

| # | Issue | Fix |
|---|---|---|
| 1 | Bundled agent could never call MCP tools — `tools:` allowlist had no MCP entries (gate left behind when 5d6d180 removed the `mcpServers` grant) | Remove the `tools:` line; omitted = inherit everything. Generator comment explains why, Anthropic-style |
| 2 | `settings.json` made the agent the **default in every project** at user scope | Deleted |
| 3 | `model: sonnet` silently overrode the user's model everywhere | Removed (inherits session model); added `maxTurns: 25` |
| 4 | Root `.mcp.json` missing the required `mcpServers` wrapper (lost in cc8ce93 retype) | Wrapper added |
| 5 | Docs said `/plugin install adspirer` — plugin is named `adspirer-advertising-agent`, so the documented install fails | Fixed at `shared/` source + `commands/setup.md`, `cookbook`, `README`, `CONNECTING.md`; re-synced all 5 targets |

## Verification
- `scripts/sync-skills.sh` regenerated all targets; manual `plugins/adspirer/` codex copy re-aligned
- `scripts/validate.sh`: 115/115
- `claude plugin validate .`: passes (version warning = deliberate SHA-versioning policy)
- Local sandboxed install test: results in PR comments

## Note for reviewers
The `/mcp` server label is documented as "find the **adspirer** server (e.g. `plugin:adspirer-advertising-agent:adspirer`)" — phrased loosely because the plugin-scoped prefix depends on the plugin id. Local install test confirms the exact string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBVt2FxKFHEXSy8mDzGrsG